### PR TITLE
Fixes for ampgsql

### DIFF
--- a/application-src/ampgsql.pl
+++ b/application-src/ampgsql.pl
@@ -491,7 +491,7 @@ sub _get_backup_info {
 	       # this works!)
                local *TAROUT;
                my $conf = $self->{'args'}->{'config'} || 'NOCONFIG';
-               my $cmd = "$self->{'runtar'} $conf $Amanda::Constants::GNUTAR --create --directory $self->{'props'}->{'pg-archivedir'} $fname | $Amanda::Constants::GNUTAR --extract --to-stdout";
+               my $cmd = "$self->{'runtar'} $conf $Amanda::Constants::GNUTAR --create --file - --directory $self->{'props'}->{'pg-archivedir'} $fname | $Amanda::Constants::GNUTAR --file - --extract --to-stdout";
                debug("running: $cmd");
                open(TAROUT, "$cmd |");
                my ($start, $end, $lab);
@@ -676,13 +676,13 @@ sub _base_backup {
 	   '--directory', $self->{'props'}->{'pg-archivedir'}, @wal_files);
    } else {
        my $dummydir = $self->_make_dummy_dir();
-       $self->{'done_cb'}->(_run_tar_totals($self,
+       $self->{'done_cb'}->(_run_tar_totals($self, '--file', '-',
            '--directory', $dummydir, "empty-incremental"));
        rmtree($dummydir);
    }
 
    # create the final tar file
-   my $size = _run_tar_totals($self, '--directory', $tmp,
+   my $size = _run_tar_totals($self, '--directory', $tmp, '--file', '-',
        $_ARCHIVE_DIR_TAR, $_DATA_DIR_TAR);
 
    $self->{'state_cb'}->($self, $end_wal);
@@ -719,11 +719,11 @@ sub _incr_backup {
    $self->{'state_cb'}->($self, $max_wal ? $max_wal : $end_wal);
 
    if (@wal_files) {
-       $self->{'done_cb'}->(_run_tar_totals($self,
+       $self->{'done_cb'}->(_run_tar_totals($self, '--file', '-',
            '--directory', $self->{'props'}->{'pg-archivedir'}, @wal_files));
    } else {
        my $dummydir = $self->_make_dummy_dir();
-       $self->{'done_cb'}->(_run_tar_totals($self,
+       $self->{'done_cb'}->(_run_tar_totals($self, '--file', '-',
            '--directory', $dummydir, "empty-incremental"));
        rmtree($dummydir);
    }


### PR DESCRIPTION
Some fixes I had to apply to get ampgsql to work on a FreeBSD 8.1 server, using Amanda v3.2.0 from the FreeBSD Ports collection.
