### PR TITLE
3.3 fixes

### DIFF
--- a/server-src/driverio.c
+++ b/server-src/driverio.c
@@ -804,7 +804,7 @@ chunker_cmd(
 				" ", disk2serial(dp),
 				"\n",  NULL);
 	} else {
-	    cmdline = vstralloc(cmdstr[cmd], "\n");
+	    cmdline = vstralloc(cmdstr[cmd], "\n", NULL);
 	}
 	break;
     default:


### PR DESCRIPTION
The following semantic patch:

---

@@
expression E != NULL;
@@

  vstralloc(..., E
- , NULL
  )

---

finds all invocations of vstralloc() with a last non-NULL argument and fixes
them. It has found one error, which this commit fixes. Can certainly also be applied to 3.1 and 3.2.
