### PR TITLE
client-src/getfsent.c: drop raw device detection heuristic

### DIFF
--- a/common-src/genversion.c
+++ b/common-src/genversion.c
@@ -246,12 +246,6 @@ main(
     prundefvar("DEV_PREFIX");
 #endif
 
-#ifdef RDEV_PREFIX
-    prvar("RDEV_PREFIX", RDEV_PREFIX);
-#else
-    prundefvar("RDEV_PREFIX");
-#endif
-
 #ifdef DUMP
     prvar("DUMP", DUMP);
     prvar("RESTORE", RESTORE);

--- a/config/amanda/devprefix.m4
+++ b/config/amanda/devprefix.m4
@@ -6,7 +6,7 @@
 #
 #   Check for the prefixes used for particular devices.
 #
-#   Defines DEV_PREFIX and RDEV_PREFIX to the appropriate prefixes.
+#   Defines DEV_PREFIX to the appropriate prefix.
 #
 AC_DEFUN([AMANDA_CHECK_DEVICE_PREFIXES],
 [
@@ -57,7 +57,6 @@ AC_DEFUN([AMANDA_CHECK_DEVICE_PREFIXES],
 	    ;;
 	*-sni-sysv4)
 	    DEV_PREFIX=/dev/dsk/
-	    RDEV_PREFIX=/dev/rdsk/
 	    CLIENT_SCRIPTS_OPT=amsinixfixdevs
 	    if ! test -d /dev/dsk; then
 		AMANDA_MSG_WARN([Run amsinixfixdevs on Sinix systems using VxFS.])
@@ -65,51 +64,28 @@ AC_DEFUN([AMANDA_CHECK_DEVICE_PREFIXES],
 	    ;;
 	*-sco3.2v4*)
 	    DEV_PREFIX=/dev/
-	    RDEV_PREFIX=/dev/
 	    ;;
 	*)
 	    CLIENT_SCRIPTS_OPT=
 	    ;;
     esac
 
-    if test "$DEV_PREFIX" && test "$RDEV_PREFIX"; then
-	AC_MSG_RESULT((predefined) $DEV_PREFIX - $RDEV_PREFIX)
+    if test "$DEV_PREFIX"; then
+	AC_MSG_RESULT((predefined) $DEV_PREFIX)
     else
 	if test -d /dev/dsk; then
 	    DEV_PREFIX=/dev/dsk/
-	    if test -d /dev/rdsk; then
-		RDEV_PREFIX=/dev/rdsk/
-	    else
-		RDEV_PREFIX=/dev/dsk/
-	    fi
 	elif test -d /dev; then
 	    DEV_PREFIX=/dev/
 
-	    # Some systems, notably Linux, do not have raw disk devices
-	    # names.  Check this by trying to see if a raw disk device name
-	    # exists using the normal raw device path prepended to the
-	    # mount point of the root filesystem.
-	    if test "$mount"; then
-		dev_name="/dev/r`basename $mount`"
-		if test -b $dev_name -o -c $dev_name; then
-		    RDEV_PREFIX=/dev/r
-		else
-		    RDEV_PREFIX=/dev/
-		fi
-	    else
-		RDEV_PREFIX=/dev/r
-	    fi
 	else
 	    # just fake it..
 	    DEV_PREFIX=/
-	    RDEV_PREFIX=/
 	fi
-	AC_MSG_RESULT($DEV_PREFIX - $RDEV_PREFIX)
+	AC_MSG_RESULT($DEV_PREFIX)
     fi
 
     AC_DEFINE_UNQUOTED(DEV_PREFIX,"${DEV_PREFIX}",
 	[Define as the prefix for disk devices, commonly /dev/ or /dev/dsk/ ])
-    AC_DEFINE_UNQUOTED(RDEV_PREFIX,"${RDEV_PREFIX}",
-	[Define as the prefix for raw disk devices, commonly /dev/r or /dev/rdsk/ ])
     AC_SUBST(CLIENT_SCRIPTS_OPT)
 ])

--- a/installcheck/catalogs/chunker-partial.cat
+++ b/installcheck/catalogs/chunker-partial.cat
@@ -14,7 +14,7 @@ planner: paths: bindir="/usr/bin" sbindir="/usr/sbin"
 planner:        libexecdir="/usr/lib" amlibexecdir="/usr/lib/amanda"
 planner:        mandir="/usr/share/man" AMANDA_TMPDIR="/tmp/amanda"
 planner:        AMANDA_DBGDIR="/var/log/amanda" CONFIG_DIR="/etc/amanda"
-planner:        DEV_PREFIX="/dev/dsk/" RDEV_PREFIX="/dev/rdsk/"
+planner:        DEV_PREFIX="/dev/dsk/"
 planner:        DUMP="/usr/sbin/ufsdump" RESTORE="/usr/sbin/ufsrestore"
 planner:        VDUMP=UNDEF VRESTORE=UNDEF XFSDUMP=UNDEF XFSRESTORE=UNDEF
 planner:        VXDUMP=UNDEF VXRESTORE=UNDEF


### PR DESCRIPTION
amname_to_devname() and search_fstab() tried to find, for a block device named
/dev/xxx/yyy, a matching raw (character) device named either /dev/rxxx/yyy or
/dev/xxx/ryyy.

But raw devices are all but obsolete on most Unixes of today: according to the
Wikipedia entry for raw devices, for instance, FreeBSD has dropped support for
raw devices as far back as FreBSD 4.0. As to Linux and many other Unixes, they
implement O_DIRECT as a flag to open(2).

What's more, it is potentially dangerous: nothing prevents someone from using
mknod(2) to make a character device expected by Amanda, but which does not match
the real underlying device at all (on Linux, this can even be done using udev).

So, drop this heuristic entirely. Leave it to the sysadmin to decide whether he
wants to use a raw device, which will only ever happen on partitions saved using
*dump anyway, and this program may even do the logic for him.
