### PR TITLE
Change prototype for validate_optionstr(), and fix two memory leaks

### DIFF
--- a/server-src/amcheck.c
+++ b/server-src/amcheck.c
@@ -1742,22 +1742,21 @@ start_host(
 	    char *calcsize;
 	    char *qname, *b64disk;
 	    char *qdevice, *b64device = NULL;
-	    GPtrArray *errarray;
-	    guint      i;
+	    gchar **errors;
 
 	    if(dp->up != DISK_READY || dp->todo != 1) {
 		continue;
 	    }
 	    qname = quote_string(dp->name);
 
-	    errarray = validate_optionstr(dp);
-	    if (errarray->len > 0) {
-		for (i=0; i < errarray->len; i++) {
-		    g_fprintf(outf, _("ERROR: %s:%s %s\n"),
-			      hostp->hostname, qname,
-			      (char *)g_ptr_array_index(errarray, i));
-		}
-		g_ptr_array_free(errarray, TRUE);
+	    errors = validate_optionstr(dp);
+
+            if (errors) {
+                gchar **ptr;
+                for (ptr = errors; *ptr; ptr++)
+                    g_fprintf(outf, "ERROR: %s:%s %s\n", hostp->hostname, qname,
+                        *ptr);
+                g_strfreev(errors);
 		amfree(qname);
 		remote_errors++;
 		continue;

--- a/server-src/amindexd.c
+++ b/server-src/amindexd.c
@@ -1644,19 +1644,19 @@ main(
 	    if (dp->line == 0) {
 		reply(200, "NODLE");
 	    } else {
-		GPtrArray *errarray;
-		guint      i;
+		gchar **errors;
 
 		b64disk = amxml_format_tag("disk", dp->name);
 		dp->host->features = their_features;
-		errarray = validate_optionstr(dp);
-		if (errarray->len > 0) {
-		    for (i=0; i < errarray->len; i++) {
-			g_debug(_("ERROR: %s:%s %s"),
-				dump_hostname, disk_name,
-				(char *)g_ptr_array_index(errarray, i));
-		    }
-		    g_ptr_array_free(errarray, TRUE);
+
+		errors = validate_optionstr(dp);
+
+                if (errors) {
+                    gchar **ptr;
+                    for (ptr = errors; *ptr; ptr++)
+                        g_debug("ERROR: %s:%s %s", dump_hostname, disk_name,
+                            *ptr);
+                    g_strfreev(errors);
 		    reply(200, "NODLE");
 		} else {
 		    optionstr = xml_optionstr(dp, 0);

--- a/server-src/diskfile.h
+++ b/server-src/diskfile.h
@@ -160,7 +160,7 @@ char *optionstr(disk_t *dp);
  *           application, eg. driver to dumper.
  *           It must be set to 0 if the result is sent to the client.
  */
-GPtrArray *validate_optionstr(disk_t *dp);
+gchar **validate_optionstr(disk_t *dp);
 char *xml_optionstr(disk_t *dp, int to_server);
 char *xml_estimate(estimatelist_t estimatelist, am_feature_t *their_features);
 char *clean_dle_str_for_client(char *dle_str);

--- a/server-src/driver.c
+++ b/server-src/driver.c
@@ -2895,7 +2895,7 @@ read_schedule(
     long long csize_;
     long long degr_nsize_;
     long long degr_csize_;
-    GPtrArray *errarray;
+    gchar **errors;
 
     (void)cookie;	/* Quiet unused parameter warning */
 
@@ -3150,15 +3150,14 @@ read_schedule(
 	}
 	remove_disk(&waitq, dp);
 
-	errarray = validate_optionstr(dp);
-	if (errarray->len > 0) {
-	    guint i;
-	    for (i=0; i < errarray->len; i++) {
-		log_add(L_FAIL, _("%s %s %s 0 [%s]"),
-			dp->host->hostname, qname,
-			sp->datestamp,
-			(char *)g_ptr_array_index(errarray, i));
-	    }
+	errors = validate_optionstr(dp);
+
+        if (errors) {
+            gchar **ptr;
+            for (ptr = errors; *ptr; ptr++)
+                log_add(L_FAIL, "%s %s %s 0 [%s]", dp->host->hostname, qname,
+                    sp->datestamp, *ptr);
+            g_strfreev(errors);
 	    amfree(qname);
 	} else {
 

--- a/server-src/planner.c
+++ b/server-src/planner.c
@@ -1468,7 +1468,7 @@ static void getsize(
 	    char *s = NULL;
 	    char *es;
 	    size_t s_len = 0;
-	    GPtrArray *errarray;
+	    gchar **errors;
 
 	    if(dp->todo == 0) continue;
 
@@ -1482,15 +1482,14 @@ static void getsize(
 
 	    qname = quote_string(dp->name);
 
-	    errarray = validate_optionstr(dp);
-	    if (errarray->len > 0) {
-		guint i;
-		for (i=0; i < errarray->len; i++) {
-		    log_add(L_FAIL, _("%s %s %s 0 [%s]"),
-			    dp->host->hostname, qname,
-			    planner_timestamp,
-			    (char *)g_ptr_array_index(errarray, i));
-		}
+	    errors = validate_optionstr(dp);
+
+            if (errors) {
+                gchar **ptr;
+                for (ptr = errors; *ptr; ptr++)
+                    log_add(L_FAIL, "%s %s %s 0 [%s]", dp->host->hostname,
+                        qname, planner_timestamp, *ptr);
+                g_strfreev(errors);
 		amfree(qname);
 		est(dp)->state = DISK_DONE;
 		continue;


### PR DESCRIPTION
validate_optionstr() returned a GPtrArray of statically allocated strings to the
caller.

It was then up to the caller to verify whether the array was non empty by peeking into it. This is the first badness: requiring the caller to peek into the GPtrArray structure itself defeats the purpose of a GPtrArray which is supposed to be an opaque (even if documented) structure, accessed only by GLib functions.

What's more, it was freed with g_ptr_array_free(..., TRUE), which attempted to
free individual elements. BUT THESE ELEMENTS WERE STATIC STRINGS!

Change the function to return a gchar *\* of dynamically allocated strings
instead (NULL if no errors), and change all four callsites. What's more, this
fixes two callsites, which would leak memory because they didn't free the array
when done (server-src/driver.c in read_schedule(), and server-src/planner.c in
getsize()).

[maybe the fact that the latter forgot to free explains why installchecks passed
for it: when I started to free correctly, glibc warned me about an invalid freed
pointer]
