### PR TITLE
server-src/dumper.c: fix a missing switch of default auth to BSDTCP

### DIFF
--- a/server-src/dumper.c
+++ b/server-src/dumper.c
@@ -2353,7 +2353,7 @@ startup_dump(
     } else {
 	authopt = strstr(options, "auth=");
 	if (auth == NULL) {
-	    auth = "BSD";
+	    auth = "BSDTCP";
 	}
 	vstrextend(&req,
 		   progname,


### PR DESCRIPTION
This instance was the only one found in the whole tree (git grep '"BSD"').
