### PR TITLE
Use more convenient GLib functions

### DIFF
--- a/amandad-src/amandad.c
+++ b/amandad-src/amandad.c
@@ -280,7 +280,7 @@ main(
 	/*
 	 * Get a driver for a security type specified after -auth=
 	 */
-	if (strncmp(argv[i], "-auth=", strlen("-auth=")) == 0) {
+	if (g_str_has_prefix(argv[i], "-auth=")) {
 	    argv[i] += strlen("-auth=");
 	    secdrv = security_getdriver(argv[i]);
 	    auth = argv[i];
@@ -288,9 +288,9 @@ main(
 		error(_("no driver for security type '%s'\n"), argv[i]);
                 /*NOTREACHED*/
 	    }
-	    if (strcmp(auth, "local") == 0 ||
-		strcmp(auth, "rsh") == 0 ||
-		strcmp(auth, "ssh") == 0) {
+	    if (g_str_equal(auth, "local") ||
+		g_str_equal(auth, "rsh") ||
+		g_str_equal(auth, "ssh")) {
 		guint i;
 		for (i=0; i < NSERVICES; i++) {
 		    services[i].active = 1;
@@ -303,7 +303,7 @@ main(
 	 * If -no-exit is specified, always run even after requests have
 	 * been satisfied.
 	 */
-	else if (strcmp(argv[i], "-no-exit") == 0) {
+	else if (g_str_equal(argv[i], "-no-exit")) {
 	    no_exit = 1;
 	    continue;
 	}
@@ -312,7 +312,7 @@ main(
 	 * Allow us to directly bind to a udp port for debugging.
 	 * This may only apply to some security types.
 	 */
-	else if (strncmp(argv[i], "-udp=", strlen("-udp=")) == 0) {
+	else if (g_str_has_prefix(argv[i], "-udp=")) {
 #ifdef WORKING_IPV6
 	    struct sockaddr_in6 sin;
 #else
@@ -356,7 +356,7 @@ main(
 	/*
 	 * Ditto for tcp ports.
 	 */
-	else if (strncmp(argv[i], "-tcp=", strlen("-tcp=")) == 0) {
+	else if (g_str_has_prefix(argv[i], "-tcp=")) {
 #ifdef WORKING_IPV6
 	    struct sockaddr_in6 sin;
 #else
@@ -412,7 +412,7 @@ main(
 	    }
 	    have_services = 1;
 
-	    if(strcmp(argv[i],"amdump") == 0) {
+	    if(g_str_equal(argv[i], "amdump")) {
 		services[0].active = 1;
 		services[1].active = 1;
 		services[2].active = 1;
@@ -420,7 +420,7 @@ main(
 	    }
 	    else {
 		for (j = 0; j < NSERVICES; j++)
-		    if (strcmp(services[j].name, argv[i]) == 0)
+		    if (g_str_equal(services[j].name, argv[i]))
 			break;
 		if (j == NSERVICES) {
 		    dbprintf(_("%s: invalid service\n"), argv[i]);
@@ -635,7 +635,7 @@ protocol_accept(
     tok = strtok(pktbody, " ");
     if (tok == NULL)
 	goto badreq;
-    if (strcmp(tok, "SERVICE") != 0)
+    if (!g_str_equal(tok, "SERVICE"))
 	goto badreq;
 
     tok = strtok(NULL, " \n");
@@ -651,7 +651,7 @@ protocol_accept(
 
     /* see if it's one we allow */
     for (i = 0; i < NSERVICES; i++)
-	if (services[i].active == 1 && strcmp(services[i].name, service) == 0)
+	if (services[i].active == 1 && g_str_equal(services[i].name, service))
 	    break;
     if (i == NSERVICES) {
 	dbprintf(_("%s: invalid service\n"), service);
@@ -671,8 +671,8 @@ protocol_accept(
     /* see if its already running */
     for (iter = serviceq; iter != NULL; iter = g_slist_next(iter)) {
 	as = (struct active_service *)iter->data;
-	    if (strcmp(as->cmd, service_path) == 0 &&
-		strcmp(as->arguments, arguments) == 0) {
+	    if (g_str_equal(as->cmd, service_path) &&
+		g_str_equal(as->arguments, arguments)) {
 		    dbprintf(_("%s %s: already running, acking req\n"),
 			service, arguments);
 		    pkt_init_empty(&pkt_out, P_ACK);
@@ -1073,7 +1073,7 @@ s_processrep(
     tok = strtok(repbuf, " ");
     if (tok == NULL)
 	goto error;
-    if (strcmp(tok, "CONNECT") == 0) {
+    if (g_str_equal(tok, "CONNECT")) {
 	char *line, *nextbuf;
 
 	/* Save the entire line */
@@ -1999,7 +1999,7 @@ amandad_get_security_conf(
     if (!string || !*string)
 	return(NULL);
 
-    if (strcmp(string, "kencrypt")==0) {
+    if (g_str_equal(string, "kencrypt")) {
 	if (amandad_kencrypt == KENCRYPT_YES)
 	    return ("yes");
 	else

--- a/amandad-src/amandad_util.c
+++ b/amandad-src/amandad_util.c
@@ -64,7 +64,7 @@ parse_g_options(
     tok = strtok(p,";");
 
     while (tok != NULL) {
-	if(strncmp(tok,"features=", 9) == 0) {
+	if(g_str_has_prefix(tok, "features=")) {
 	    char *t = tok+9;
 	    char *u = strchr(t, ';');
 	    if (u)
@@ -85,7 +85,7 @@ parse_g_options(
 	    if (u)
 	       *u = ';';
 	}
-	else if(strncmp(tok,"hostname=", 9) == 0) {
+	else if(g_str_has_prefix(tok, "hostname=")) {
 	    if(g_options->hostname != NULL) {
 		dbprintf(_("multiple hostname option\n"));
 		if(verbose) {
@@ -95,7 +95,7 @@ parse_g_options(
 	    }
 	    g_options->hostname = g_strdup(tok+9);
 	}
-	else if(strncmp(tok,"auth=", 5) == 0) {
+	else if(g_str_has_prefix(tok, "auth=")) {
 	    if(g_options->auth != NULL) {
 		dbprintf(_("multiple auth option\n"));
 		if(verbose) {
@@ -105,7 +105,7 @@ parse_g_options(
 	    }
 	    g_options->auth = g_strdup(tok+5);
 	}
-	else if(strncmp(tok,"maxdumps=", 9) == 0) {
+	else if(g_str_has_prefix(tok, "maxdumps=")) {
 	    if(g_options->maxdumps != 0) {
 		dbprintf(_("multiple maxdumps option\n"));
 		if(verbose) {
@@ -135,7 +135,7 @@ parse_g_options(
 		}
 	    }
 	}
-	else if(strncmp(tok,"config=", 7) == 0) {
+	else if(g_str_has_prefix(tok, "config=")) {
 	    if(g_options->config != NULL) {
 		dbprintf(_("multiple config option\n"));
 		if(verbose) {

--- a/amar-src/amar-test.c
+++ b/amar-src/amar-test.c
@@ -319,7 +319,7 @@ check_gerror_matches_(
     const char *fn)
 {
     if (!ok && error) {
-	if (0 != strcmp(matches, error->message)) {
+	if (!g_str_equal(matches, error->message)) {
 	    EXPECT_FAILURE(
 		    "%s produced error '%s' but expected '%s'\n",
 		    fn, error->message, matches);

--- a/amar-src/amarchiver.c
+++ b/amar-src/amarchiver.c
@@ -58,7 +58,7 @@ do_create(char *opt_file, int opt_verbose, int argc, char **argv)
     int i, fd_out, fd_in;
     off_t filesize = 0;
 
-    if (opt_file != NULL && strcmp(opt_file,"-") != 0) {
+    if (opt_file != NULL && !g_str_equal(opt_file, "-")) {
 	fd_out = open(opt_file, O_CREAT|O_WRONLY|O_TRUNC, 0660);
 	if (fd_out <= 0) {
 	    error("open of '%s' failed: %s\n", opt_file, strerror(errno));
@@ -135,7 +135,7 @@ extract_file_start_cb(
 	*ignore = TRUE;
 	for (i = 0; i < ud->argc; i++) {
 	    if (strlen(ud->argv[i]) == filename_len
-		&& 0 == strcmp(ud->argv[i], *file_data))
+		&& g_str_equal(ud->argv[i], *file_data))
 		*ignore = FALSE;
 	}
     }
@@ -224,7 +224,7 @@ do_extract(
     ud.argc = argc;
     ud.verbose = opt_verbose;
 
-    if (opt_file && strcmp(opt_file,"-") != 0) {
+    if (opt_file && !g_str_equal(opt_file, "-")) {
 	fd_in = open(opt_file, O_RDONLY);
 	if (fd_in <= 0) {
 	    error("open of '%s' failed: %s\n", opt_file, strerror(errno));
@@ -273,7 +273,7 @@ do_list(
 	{ 0, 0, NULL, NULL },
     };
 
-    if (opt_file && strcmp(opt_file,"-") != 0) {
+    if (opt_file && !g_str_equal(opt_file, "-")) {
 	fd_in = open(opt_file, O_RDONLY);
 	if (fd_in <= 0) {
 	    error("open of '%s' failed: %s\n", opt_file, strerror(errno));

--- a/application-src/amgtar.c
+++ b/application-src/amgtar.c
@@ -326,7 +326,7 @@ main(
 
     /* drop root privileges */
     if (!set_root_privs(0)) {
-	if (strcmp(argv[1], "selfcheck") == 0) {
+	if (g_str_equal(argv[1], "selfcheck")) {
 	    printf("ERROR amgtar must be run setuid root\n");
 	}
 	error(_("amgtar must be run setuid root"));
@@ -586,17 +586,17 @@ main(
 	}
     }
 
-    if (strcmp(command, "support") == 0) {
+    if (g_str_equal(command, "support")) {
 	amgtar_support(&argument);
-    } else if (strcmp(command, "selfcheck") == 0) {
+    } else if (g_str_equal(command, "selfcheck")) {
 	amgtar_selfcheck(&argument);
-    } else if (strcmp(command, "estimate") == 0) {
+    } else if (g_str_equal(command, "estimate")) {
 	amgtar_estimate(&argument);
-    } else if (strcmp(command, "backup") == 0) {
+    } else if (g_str_equal(command, "backup")) {
 	amgtar_backup(&argument);
-    } else if (strcmp(command, "restore") == 0) {
+    } else if (g_str_equal(command, "restore")) {
 	amgtar_restore(&argument);
-    } else if (strcmp(command, "validate") == 0) {
+    } else if (g_str_equal(command, "validate")) {
 	amgtar_validate(&argument);
     } else {
 	dbprintf("Unknown command `%s'.\n", command);

--- a/application-src/amstar.c
+++ b/application-src/amstar.c
@@ -206,7 +206,7 @@ main(
 
     /* drop root privileges */
     if (!set_root_privs(0)) {
-	if (strcmp(argv[1], "selfcheck") == 0) {
+	if (g_str_equal(argv[1], "selfcheck")) {
 	    printf("ERROR amstar must be run setuid root\n");
 	}
 	error(_("amstar must be run setuid root"));
@@ -389,17 +389,17 @@ main(
     re_table = build_re_table(init_re_table, normal_message, ignore_message,
 			      strange_message);
 
-    if (strcmp(command, "support") == 0) {
+    if (g_str_equal(command, "support")) {
 	amstar_support(&argument);
-    } else if (strcmp(command, "selfcheck") == 0) {
+    } else if (g_str_equal(command, "selfcheck")) {
 	amstar_selfcheck(&argument);
-    } else if (strcmp(command, "estimate") == 0) {
+    } else if (g_str_equal(command, "estimate")) {
 	amstar_estimate(&argument);
-    } else if (strcmp(command, "backup") == 0) {
+    } else if (g_str_equal(command, "backup")) {
 	amstar_backup(&argument);
-    } else if (strcmp(command, "restore") == 0) {
+    } else if (g_str_equal(command, "restore")) {
 	amstar_restore(&argument);
-    } else if (strcmp(command, "validate") == 0) {
+    } else if (g_str_equal(command, "validate")) {
 	amstar_validate(&argument);
     } else {
 	fprintf(stderr, "Unknown command `%s'.\n", command);
@@ -919,18 +919,18 @@ amstar_restore(
 	    char  line[2*PATH_MAX+2];
 	    while (fgets(line, 2*PATH_MAX, include_list)) {
 		line[strlen(line)-1] = '\0'; /* remove '\n' */
-		if (strncmp(line, "./", 2) == 0)
+		if (g_str_has_prefix(line, "./"))
 		    g_ptr_array_add(argv_ptr, g_strdup(line+2)); /* remove ./ */
-		else if (strcmp(line, ".") != 0)
+		else if (!g_str_equal(line, "."))
 		    g_ptr_array_add(argv_ptr, g_strdup(line));
 	    }
 	    fclose(include_list);
 	}
     }
     for (j=1; j< argument->argc; j++) {
-	if (strncmp(argument->argv[j], "./", 2) == 0)
+	if (g_str_has_prefix(argument->argv[j], "./"))
 	    g_ptr_array_add(argv_ptr, g_strdup(argument->argv[j]+2));/*remove ./ */
-	else if (strcmp(argument->argv[j], ".") != 0)
+	else if (!g_str_equal(argument->argv[j], "."))
 	    g_ptr_array_add(argv_ptr, g_strdup(argument->argv[j]));
     }
     g_ptr_array_add(argv_ptr, NULL);
@@ -1073,7 +1073,7 @@ static GPtrArray *amstar_build_argv(
 	for (excl = argument->dle.exclude_file->first; excl != NULL;
 	     excl = excl->next) {
 	    char *ex;
-	    if (strcmp(excl->name, "./") == 0) {
+	    if (g_str_equal(excl->name, "./")) {
 		ex = g_strdup_printf("pat=%s", excl->name+2);
 	    } else {
 		ex = g_strdup_printf("pat=%s", excl->name);
@@ -1093,7 +1093,7 @@ static GPtrArray *amstar_build_argv(
 		while ((aexc = agets(exclude)) != NULL) {
 		    if (aexc[0] != '\0') {
 			char *ex;
-			if (strcmp(aexc, "./") == 0) {
+			if (g_str_equal(aexc, "./")) {
 			    ex = g_strdup_printf("pat=%s", aexc+2);
 			} else {
 			    ex = g_strdup_printf("pat=%s", aexc);

--- a/client-src/amandates.c
+++ b/client-src/amandates.c
@@ -345,7 +345,7 @@ import_dumpdates(
 	}
 	dumpdate = unctime(s-1);
 
-	if(strcmp(fname, devname) != 0 || level < 0 || level >= DUMP_LEVELS) {
+	if(!g_str_equal(fname, devname) || level < 0 || level >= DUMP_LEVELS) {
 	    continue;
 	}
 

--- a/client-src/calcsize.c
+++ b/client-src/calcsize.c
@@ -201,7 +201,7 @@ main(
     }
 
     dbprintf(_("config: %s\n"), *argv);
-    if (strcmp(*argv, "NOCONFIG") != 0) {
+    if (!g_str_equal(*argv, "NOCONFIG")) {
 	dbrename(*argv, DBG_SUBDIR_CLIENT);
     }
     argc--;
@@ -209,7 +209,7 @@ main(
 
     /* parse backup program name */
 
-    if(strcmp(*argv, "DUMP") == 0) {
+    if(g_str_equal(*argv, "DUMP")) {
 #if !defined(DUMP) && !defined(XFSDUMP)
 	error("dump not available on this system");
 	/*NOTREACHED*/
@@ -219,7 +219,7 @@ main(
 	final_size = final_size_dump;
 #endif
     }
-    else if(strcmp(*argv, "GNUTAR") == 0) {
+    else if(g_str_equal(*argv, "GNUTAR")) {
 #ifndef GNUTAR
 	error("gnutar not available on this system");
 	/*NOTREACHED*/
@@ -257,7 +257,7 @@ main(
 	/*NOTREACHED*/
     }
 
-    if ((argc > 1) && strcmp(*argv,"-X") == 0) {
+    if ((argc > 1) && g_str_equal(*argv, "-X")) {
 	argv++;
 
 	if (!(use_gtar_excl || use_star_excl)) {
@@ -286,7 +286,7 @@ main(
 	use_gtar_excl = use_star_excl = 0;
     }
 
-    if ((argc > 1) && strcmp(*argv,"-I") == 0) {
+    if ((argc > 1) && g_str_equal(*argv, "-I")) {
 	argv++;
 	
 	filename = g_strdup(*argv);

--- a/client-src/client_util.c
+++ b/client-src/client_util.c
@@ -135,9 +135,9 @@ build_name(
 	    continue;
 	}
 	d_name_len = strlen(entry->d_name);
-	if(strncmp(test_name, entry->d_name, match_len) != 0
+	if(!g_str_has_prefix(test_name, entry->d_name)
 	   || d_name_len < match_len + 14 + 8
-	   || strcmp(entry->d_name+ d_name_len - 7, exin) != 0) {
+	   || !g_str_equal(entry->d_name + d_name_len - 7, exin)) {
 	    continue;				/* not one of our files */
 	}
 	if(strcmp(entry->d_name, test_name) < 0) {
@@ -233,7 +233,7 @@ add_include(
 	ainc[l-1] = '\0';
 	l--;
     }
-    if (strncmp(ainc, "./", 2) != 0) {
+    if (!g_str_has_prefix(ainc, "./")) {
         quoted = quote_string(ainc);
         dbprintf(_("include must start with './' (%s)\n"), quoted);
 	if(verbose) {
@@ -610,7 +610,7 @@ parse_options(
 	    }
 	    dle->exclude_optional = 1;
 	}
-	else if (strcmp(tok, "include-optional") == 0) {
+	else if (g_str_equal(tok, "include-optional")) {
 	    if (dle->include_optional != 0) {
 		dbprintf(_("multiple include-optional option\n"));
 		if (verbose) {
@@ -642,7 +642,7 @@ parse_options(
 	else if (BSTRNCMP(tok,"kencrypt") == 0) {
 	    dle->kencrypt = 1;
 	}
-	else if (strcmp(tok,"|") != 0) {
+	else if (!g_str_equal(tok, "|")) {
 	    quoted = quote_string(tok);
 	    dbprintf(_("unknown option %s\n"), quoted);
 	    if (verbose) {
@@ -956,83 +956,83 @@ backup_support_option(
     }
     while((line = agets(streamout)) != NULL) {
 	dbprintf(_("support line: %s\n"), line);
-	if (strncmp(line,"CONFIG ", 7) == 0) {
-	    if (strcmp(line+7, "YES") == 0)
+	if (g_str_has_prefix(line, "CONFIG ")) {
+	    if (g_str_equal(line + 7, "YES"))
 		bsu->config = 1;
-	} else if (strncmp(line,"HOST ", 5) == 0) {
-	    if (strcmp(line+5, "YES") == 0)
+	} else if (g_str_has_prefix(line, "HOST ")) {
+	    if (g_str_equal(line + 5, "YES"))
 	    bsu->host = 1;
-	} else if (strncmp(line,"DISK ", 5) == 0) {
-	    if (strcmp(line+5, "YES") == 0)
+	} else if (g_str_has_prefix(line, "DISK ")) {
+	    if (g_str_equal(line + 5, "YES"))
 		bsu->disk = 1;
-	} else if (strncmp(line,"INDEX-LINE ", 11) == 0) {
-	    if (strcmp(line+11, "YES") == 0)
+	} else if (g_str_has_prefix(line, "INDEX-LINE ")) {
+	    if (g_str_equal(line + 11, "YES"))
 		bsu->index_line = 1;
-	} else if (strncmp(line,"INDEX-XML ", 10) == 0) {
-	    if (strcmp(line+10, "YES") == 0)
+	} else if (g_str_has_prefix(line, "INDEX-XML ")) {
+	    if (g_str_equal(line + 10, "YES"))
 		bsu->index_xml = 1;
-	} else if (strncmp(line,"MESSAGE-LINE ", 13) == 0) {
-	    if (strcmp(line+13, "YES") == 0)
+	} else if (g_str_has_prefix(line, "MESSAGE-LINE ")) {
+	    if (g_str_equal(line + 13, "YES"))
 		bsu->message_line = 1;
-	} else if (strncmp(line,"MESSAGE-XML ", 12) == 0) {
-	    if (strcmp(line+12, "YES") == 0)
+	} else if (g_str_has_prefix(line, "MESSAGE-XML ")) {
+	    if (g_str_equal(line + 12, "YES"))
 		bsu->message_xml = 1;
-	} else if (strncmp(line,"RECORD ", 7) == 0) {
-	    if (strcmp(line+7, "YES") == 0)
+	} else if (g_str_has_prefix(line, "RECORD ")) {
+	    if (g_str_equal(line + 7, "YES"))
 		bsu->record = 1;
-	} else if (strncmp(line,"INCLUDE-FILE ", 13) == 0) {
-	    if (strcmp(line+13, "YES") == 0)
+	} else if (g_str_has_prefix(line, "INCLUDE-FILE ")) {
+	    if (g_str_equal(line + 13, "YES"))
 		bsu->include_file = 1;
-	} else if (strncmp(line,"INCLUDE-LIST ", 13) == 0) {
-	    if (strcmp(line+13, "YES") == 0)
+	} else if (g_str_has_prefix(line, "INCLUDE-LIST ")) {
+	    if (g_str_equal(line + 13, "YES"))
 		bsu->include_list = 1;
-	} else if (strncmp(line,"INCLUDE-LIST-GLOB ", 17) == 0) {
-	    if (strcmp(line+17, "YES") == 0)
+	} else if (g_str_has_prefix(line, "INCLUDE-LIST-GLOB ")) {
+	    if (g_str_equal(line + 17, "YES"))
 		bsu->include_list_glob = 1;
-	} else if (strncmp(line,"INCLUDE-OPTIONAL ", 17) == 0) {
-	    if (strcmp(line+17, "YES") == 0)
+	} else if (g_str_has_prefix(line, "INCLUDE-OPTIONAL ")) {
+	    if (g_str_equal(line + 17, "YES"))
 		bsu->include_optional = 1;
-	} else if (strncmp(line,"EXCLUDE-FILE ", 13) == 0) {
-	    if (strcmp(line+13, "YES") == 0)
+	} else if (g_str_has_prefix(line, "EXCLUDE-FILE ")) {
+	    if (g_str_equal(line + 13, "YES"))
 		bsu->exclude_file = 1;
-	} else if (strncmp(line,"EXCLUDE-LIST ", 13) == 0) {
-	    if (strcmp(line+13, "YES") == 0)
+	} else if (g_str_has_prefix(line, "EXCLUDE-LIST ")) {
+	    if (g_str_equal(line + 13, "YES"))
 		bsu->exclude_list = 1;
-	} else if (strncmp(line,"EXCLUDE-LIST-GLOB ", 17) == 0) {
-	    if (strcmp(line+17, "YES") == 0)
+	} else if (g_str_has_prefix(line, "EXCLUDE-LIST-GLOB ")) {
+	    if (g_str_equal(line + 17, "YES"))
 		bsu->exclude_list_glob = 1;
-	} else if (strncmp(line,"EXCLUDE-OPTIONAL ", 17) == 0) {
-	    if (strcmp(line+17, "YES") == 0)
+	} else if (g_str_has_prefix(line, "EXCLUDE-OPTIONAL ")) {
+	    if (g_str_equal(line + 17, "YES"))
 		bsu->exclude_optional = 1;
-	} else if (strncmp(line,"COLLECTION ", 11) == 0) {
-	    if (strcmp(line+11, "YES") == 0)
+	} else if (g_str_has_prefix(line, "COLLECTION ")) {
+	    if (g_str_equal(line + 11, "YES"))
 		bsu->collection = 1;
-	} else if (strncmp(line,"CALCSIZE ", 9) == 0) {
-	    if (strcmp(line+9, "YES") == 0)
+	} else if (g_str_has_prefix(line, "CALCSIZE ")) {
+	    if (g_str_equal(line + 9, "YES"))
 		bsu->calcsize = 1;
-	} else if (strncmp(line,"CLIENT-ESTIMATE ", 16) == 0) {
-	    if (strcmp(line+16, "YES") == 0)
+	} else if (g_str_has_prefix(line, "CLIENT-ESTIMATE ")) {
+	    if (g_str_equal(line + 16, "YES"))
 		bsu->client_estimate = 1;
-	} else if (strncmp(line,"MULTI-ESTIMATE ", 15) == 0) {
-	    if (strcmp(line+15, "YES") == 0)
+	} else if (g_str_has_prefix(line, "MULTI-ESTIMATE ")) {
+	    if (g_str_equal(line + 15, "YES"))
 		bsu->multi_estimate = 1;
-	} else if (strncmp(line,"MAX-LEVEL ", 10) == 0) {
+	} else if (g_str_has_prefix(line, "MAX-LEVEL ")) {
 	    bsu->max_level  = atoi(line+10);
-	} else if (strncmp(line,"RECOVER-MODE ", 13) == 0) {
+	} else if (g_str_has_prefix(line, "RECOVER-MODE ")) {
 	    if (strcasecmp(line+13, "SMB") == 0)
 		bsu->smb_recover_mode = 1;
-	} else if (strncmp(line,"DATA-PATH ", 10) == 0) {
+	} else if (g_str_has_prefix(line, "DATA-PATH ")) {
 	    if (strcasecmp(line+10, "AMANDA") == 0)
 		bsu->data_path_set |= DATA_PATH_AMANDA;
 	    else if (strcasecmp(line+10, "DIRECTTCP") == 0)
 		bsu->data_path_set |= DATA_PATH_DIRECTTCP;
-	} else if (strncmp(line,"RECOVER-PATH ", 13) == 0) {
+	} else if (g_str_has_prefix(line, "RECOVER-PATH ")) {
 	    if (strcasecmp(line+13, "CWD") == 0)
 		bsu->recover_path = RECOVER_PATH_CWD;
 	    else if (strcasecmp(line+13, "REMOTE") == 0)
 		bsu->recover_path = RECOVER_PATH_REMOTE;
-	} else if (strncmp(line,"AMFEATURES ", 11) == 0) {
-	    if (strcmp(line+11, "YES") == 0)
+	} else if (g_str_has_prefix(line, "AMFEATURES ")) {
+	    if (g_str_equal(line + 11, "YES"))
 		bsu->features = 1;
 	} else {
 	    dbprintf(_("Invalid support line: %s\n"), line);
@@ -1549,7 +1549,7 @@ run_calcsize(
 	if (line[0] == '\0' || (int)strlen(line) <= len)
 	    continue;
 	/* Don't use sscanf for qdisk because it can have a '%'. */
-	if (strncmp(line, qdisk, len) == 0 &&
+	if (g_str_has_prefix(line, qdisk) &&
 	    sscanf(line+len, match_expr, &level, &size_) == 2) {
 	    g_printf("%d %lld %d\n", level, size_, 1); /* write to sendsize */
 	    dbprintf(_("estimate size for %s level %d: %lld KB\n"),
@@ -1775,15 +1775,15 @@ add_type_table(
 	    GSList *mes;
 
 	    for (mes = normal_message; mes != NULL; mes = mes->next) {
-		if (strcmp(rp->regex, (char *)mes->data) == 0)
+		if (g_str_equal(rp->regex, (char *)mes->data))
 		    found = 1;
 	    }
 	    for (mes = ignore_message; mes != NULL; mes = mes->next) {
-		if (strcmp(rp->regex, (char *)mes->data) == 0)
+		if (g_str_equal(rp->regex, (char *)mes->data))
 		    found = 1;
 	    }
 	    for (mes = strange_message; mes != NULL; mes = mes->next) {
-		if (strcmp(rp->regex, (char *)mes->data) == 0)
+		if (g_str_equal(rp->regex, (char *)mes->data))
 		    found = 1;
 	    }
 	    if (found == 0) {

--- a/client-src/findpass.c
+++ b/client-src/findpass.c
@@ -67,7 +67,7 @@ findpass(
       if (ch && ch != '#') {
 	s[-1] = '\0';				/* terminate disk name */
 	d = unquote_string(qname);
-	if ((strcmp(d,"*") == 0) || (strcmp(disk, d) == 0)) {
+	if ((g_str_equal(d, "*")) || (g_str_equal(disk, d))) {
 	  skip_whitespace(s, ch);		/* find start of password */
 	  if (ch && ch != '#') {
 	    pw = s - 1;				/* start of password */

--- a/client-src/getfsent.c
+++ b/client-src/getfsent.c
@@ -303,7 +303,7 @@ get_fstab_nextentry(
 	fsent->mntopts = "rw";
     } else {
 	fsent->fstype = "";
-	if (strcmp(fsent->mntopts, "-r") == 0) {
+	if (g_str_equal(fsent->mntopts, "-r")) {
 	    fsent->mntopts = "ro";
 	}
     }
@@ -512,12 +512,12 @@ is_local_fstype(
 
     /* just eliminate fstypes known to be remote or unsavable */
 
-    return strcmp(fsent->fstype, "nfs") != 0 && /* NFS */
-	   strcmp(fsent->fstype, "afs") != 0 &&	/* Andrew Filesystem */
-	   strcmp(fsent->fstype, "swap") != 0 && /* Swap */
-	   strcmp(fsent->fstype, "iso9660") != 0 && /* CDROM */
-	   strcmp(fsent->fstype, "hs") != 0 && /* CDROM */
-	   strcmp(fsent->fstype, "piofs") != 0;	/* an AIX printer thing? */
+    return !g_str_equal(fsent->fstype, "nfs") && /* NFS */
+	   !g_str_equal(fsent->fstype, "afs") &&	/* Andrew Filesystem */
+	   !g_str_equal(fsent->fstype, "swap") && /* Swap */
+	   !g_str_equal(fsent->fstype, "iso9660") && /* CDROM */
+	   !g_str_equal(fsent->fstype, "hs") && /* CDROM */
+	   !g_str_equal(fsent->fstype, "piofs");	/* an AIX printer thing? */
 }
 
 

--- a/client-src/killpgrp.c
+++ b/client-src/killpgrp.c
@@ -84,7 +84,7 @@ main(
     }
     dbprintf(_("version %s\n"), VERSION);
     dbprintf(_("config: %s\n"), argv[1]);
-    if (strcmp(argv[1], "NOCONFIG") != 0)
+    if (!g_str_equal(argv[1], "NOCONFIG"))
 	dbrename(argv[1], DBG_SUBDIR_CLIENT);
 
 #ifdef WANT_SETUID_CLIENT

--- a/client-src/rundump.c
+++ b/client-src/rundump.c
@@ -119,14 +119,14 @@ main(
     argv++;
 
     dbprintf(_("config: %s\n"), argv[0]);
-    if (strcmp(argv[0], "NOCONFIG") != 0)
+    if (!g_str_equal(argv[0], "NOCONFIG"))
 	dbrename(argv[0], DBG_SUBDIR_CLIENT);
     argc--;
     argv++;
 
 #ifdef XFSDUMP
 
-    if (strcmp(argv[0], "xfsdump") == 0)
+    if (g_str_equal(argv[0], "xfsdump"))
         dump_program = XFSDUMP;
     else /* strcmp(argv[0], "xfsdump") != 0 */
 
@@ -134,7 +134,7 @@ main(
 
 #ifdef VXDUMP
 
-    if (strcmp(argv[0], "vxdump") == 0)
+    if (g_str_equal(argv[0], "vxdump"))
         dump_program = VXDUMP;
     else /* strcmp(argv[0], "vxdump") != 0 */
 
@@ -142,7 +142,7 @@ main(
 
 #ifdef VDUMP
 
-    if (strcmp(argv[0], "vdump") == 0)
+    if (g_str_equal(argv[0], "vdump"))
 	dump_program = VDUMP;
     else /* strcmp(argv[0], "vdump") != 0 */
 

--- a/client-src/runtar.c
+++ b/client-src/runtar.c
@@ -80,7 +80,7 @@ main(
 
     dbprintf(_("version %s\n"), VERSION);
 
-    if (strcmp(argv[3], "--create") != 0) {
+    if (!g_str_equal(argv[3], "--create")) {
 	error(_("Can only be used to create tar archives\n"));
 	/*NOTREACHED*/
     }
@@ -131,7 +131,7 @@ main(
     argv++;
 
     dbprintf(_("config: %s\n"), argv[0]);
-    if (strcmp(argv[0], "NOCONFIG") != 0)
+    if (!g_str_equal(argv[0], "NOCONFIG"))
 	dbrename(argv[0], DBG_SUBDIR_CLIENT);
     argc--;
     argv++;

--- a/client-src/selfcheck.c
+++ b/client-src/selfcheck.c
@@ -122,7 +122,7 @@ main(
     startclock();
     dbprintf(_("version %s\n"), VERSION);
 
-    if(argc > 2 && strcmp(argv[1], "amandad") == 0) {
+    if(argc > 2 && g_str_equal(argv[1], "amandad")) {
 	amandad_auth = g_strdup(argv[2]);
     }
 
@@ -202,7 +202,7 @@ main(
 	s[-1] = '\0';				/* terminate the program name */
 
 	dle->program_is_application_api = 0;
-	if(strcmp(dle->program,"APPLICATION")==0) {
+	if(g_str_equal(dle->program, "APPLICATION")) {
 	    dle->program_is_application_api = 1;
 	    skip_whitespace(s, ch);		/* find dumper name */
 	    if (ch == '\0') {
@@ -384,7 +384,7 @@ check_options(
 	need_calcsize=1;
     }
 
-    if (strcmp(dle->program,"GNUTAR") == 0) {
+    if (g_str_equal(dle->program, "GNUTAR")) {
 	need_gnutar=1;
         if(dle->device && dle->device[0] == '/' && dle->device[1] == '/') {
 	    if(dle->exclude_file && dle->exclude_file->nb_element > 1) {
@@ -423,7 +423,7 @@ check_options(
 	}
     }
 
-    if (strcmp(dle->program,"DUMP") == 0) {
+    if (g_str_equal(dle->program, "DUMP")) {
 	if (dle->exclude_file && dle->exclude_file->nb_element > 0) {
 	    g_printf(_("ERROR [DUMP does not support exclude file]\n"));
 	}
@@ -442,7 +442,7 @@ check_options(
 #ifndef AIX_BACKUP
 #ifdef VDUMP
 #ifdef DUMP
-	if (dle->device && strcmp(amname_to_fstype(dle->device), "advfs") == 0)
+	if (dle->device && g_str_equal(amname_to_fstype(dle->device), "advfs"))
 #else
 	if (1)
 #endif
@@ -456,7 +456,7 @@ check_options(
 #endif /* VDUMP */
 #ifdef XFSDUMP
 #ifdef DUMP
-	if (dle->device && strcmp(amname_to_fstype(dle->device), "xfs") == 0)
+	if (dle->device && g_str_equal(amname_to_fstype(dle->device), "xfs"))
 #else
 	if (1)
 #endif
@@ -470,7 +470,7 @@ check_options(
 #endif /* XFSDUMP */
 #ifdef VXDUMP
 #ifdef DUMP
-	if (dle->device && strcmp(amname_to_fstype(dle->device), "vxfs") == 0)
+	if (dle->device && g_str_equal(amname_to_fstype(dle->device), "vxfs"))
 #else
 	if (1)
 #endif
@@ -501,7 +501,7 @@ check_options(
 	if (strcasecmp(dle->auth, amandad_auth) != 0) {
 	    g_fprintf(stdout,_("ERROR [client configured for auth=%s while server requested '%s']\n"),
 		    amandad_auth, dle->auth);
-	    if (strcmp(dle->auth, "ssh") == 0)  {	
+	    if (g_str_equal(dle->auth, "ssh"))  {	
 		g_fprintf(stderr, _("ERROR [The auth in ~/.ssh/authorized_keys "
 				  "should be \"--auth=ssh\", or use another auth "
 				  " for the DLE]\n"));
@@ -548,7 +548,7 @@ check_disk(
 	    }
 	}
 
-	if (strcmp(dle->program, "GNUTAR")==0) {
+	if (g_str_equal(dle->program, "GNUTAR")) {
             if(dle->device[0] == '/' && dle->device[1] == '/') {
 		#ifdef SAMBA_CLIENT
 		int nullfd, checkerr;
@@ -696,7 +696,7 @@ check_disk(
 	    amode = F_OK;
 	    amfree(device);
 	    device = amname_to_dirname(dle->device);
-	} else if (strcmp(dle->program, "DUMP") == 0) {
+	} else if (g_str_equal(dle->program, "DUMP")) {
 	    if(dle->device[0] == '/' && dle->device[1] == '/') {
 		err = g_strdup_printf(
 		  _("The DUMP program cannot handle samba shares, use GNUTAR: %s"),
@@ -705,7 +705,7 @@ check_disk(
 	    }
 #ifdef VDUMP								/* { */
 #ifdef DUMP								/* { */
-            if (strcmp(amname_to_fstype(dle->device), "advfs") == 0)
+            if (g_str_equal(amname_to_fstype(dle->device), "advfs"))
 #else									/* }{*/
 	    if (1)
 #endif									/* } */

--- a/client-src/sendbackup-dump.c
+++ b/client-src/sendbackup-dump.c
@@ -225,7 +225,7 @@ start_backup(
     /* normal dump */
 #ifdef XFSDUMP						/* { */
 #ifdef DUMP						/* { */
-    if (strcmp(amname_to_fstype(dle->device), "xfs") == 0)
+    if (g_str_equal(amname_to_fstype(dle->device), "xfs"))
 #else							/* } { */
     if (1)
 #endif							/* } */
@@ -265,7 +265,7 @@ start_backup(
 #endif							/* } */
 #ifdef VXDUMP						/* { */
 #ifdef DUMP
-    if (strcmp(amname_to_fstype(dle->device), "vxfs") == 0)
+    if (g_str_equal(amname_to_fstype(dle->device), "vxfs"))
 #else
     if (1)
 #endif
@@ -320,7 +320,7 @@ char *progname;
 
 #ifdef VDUMP						/* { */
 #ifdef DUMP
-    if (strcmp(amname_to_fstype(dle->device), "advfs") == 0)
+    if (g_str_equal(amname_to_fstype(dle->device), "advfs"))
 #else
     if (1)
 #endif

--- a/client-src/sendbackup.c
+++ b/client-src/sendbackup.c
@@ -148,7 +148,7 @@ main(
     /* Don't die when interrupt received */
     signal(SIGINT, SIG_IGN);
 
-    if(argc > 1 && strcmp(argv[1],"-t") == 0) {
+    if(argc > 1 && g_str_equal(argv[1], "-t")) {
 	interactive = 1;
 	argc--;
 	argv++;
@@ -162,7 +162,7 @@ main(
     startclock();
     dbprintf(_("Version %s\n"), VERSION);
 
-    if(argc > 2 && strcmp(argv[1], "amandad") == 0) {
+    if(argc > 2 && g_str_equal(argv[1], "amandad")) {
 	amandad_auth = g_strdup(argv[2]);
     }
 
@@ -246,7 +246,7 @@ main(
 	skip_non_whitespace(s, ch);
 	s[-1] = '\0';
 
-        if (strcmp(dle->program, "APPLICATION")==0) {
+        if (g_str_equal(dle->program, "APPLICATION")) {
             dle->program_is_application_api=1;
             skip_whitespace(s, ch);             /* find dumper name */
             if (ch == '\0') {
@@ -393,7 +393,7 @@ main(
 	/* check that the application_api exist */
     } else {
 	for(i = 0; programs[i]; i++) {
-	    if (strcmp(programs[i]->name, dle->program) == 0) {
+	    if (g_str_equal(programs[i]->name, dle->program)) {
 		break;
 	    }
 	}

--- a/client-src/sendsize.c
+++ b/client-src/sendsize.c
@@ -254,7 +254,7 @@ main(
 	    dle->program = s - 1;
 	    skip_non_whitespace(s, ch);
 	    s[-1] = '\0';
-	    if (strcmp(dle->program,"APPLICATION") == 0) {
+	    if (g_str_equal(dle->program, "APPLICATION")) {
 		dle->program_is_application_api=1;
 		skip_whitespace(s, ch);		/* find dumper name */
 		if (ch == '\0') {
@@ -268,7 +268,7 @@ main(
 	else {
 	    dle->estimatelist = g_slist_append(dle->estimatelist,
 					       GINT_TO_POINTER(ES_CLIENT));
-	    if (strcmp(dle->program,"APPLICATION") == 0) {
+	    if (g_str_equal(dle->program, "APPLICATION")) {
 		dle->program_is_application_api=1;
 		skip_whitespace(s, ch);		/* find dumper name */
 		if (ch == '\0') {
@@ -622,7 +622,7 @@ dle_add_diskest(
 	    need_amandates = TRUE;
     }
 
-    if (strcmp(dle->program, "GNUTAR") == 0) {
+    if (g_str_equal(dle->program, "GNUTAR")) {
 	/* GNUTAR only needs amandates if gnutar_list_dir is NULL */
 	char *gnutar_list_dir = getconf_str(CNF_GNUTAR_LIST_DIR);
 	if (!gnutar_list_dir || !*gnutar_list_dir)
@@ -660,7 +660,7 @@ dle_add_diskest(
     }
 
     for(curp = est_list; curp != NULL; curp = curp->next) {
-	if(strcmp(curp->dle->disk, dle->disk) == 0) {
+	if(g_str_equal(curp->dle->disk, dle->disk)) {
 	    /* already have disk info, just note the level request */
 	    levellist = dle->levellist;
 	    while (levellist != NULL) {
@@ -792,18 +792,18 @@ calc_estimates(
 	    generic_calc_estimates(est);
 	} else if (client_method == ES_CLIENT) {
 #ifndef USE_GENERIC_CALCSIZE
-	    if (strcmp(est->dle->program, "DUMP") == 0)
+	    if (g_str_equal(est->dle->program, "DUMP"))
 		dump_calc_estimates(est);
 	    else
 #endif
 #ifdef SAMBA_CLIENT
-	    if (strcmp(est->dle->program, "GNUTAR") == 0 &&
+	    if (g_str_equal(est->dle->program, "GNUTAR") &&
 		est->dle->device[0] == '/' && est->dle->device[1] == '/')
 		smbtar_calc_estimates(est);
 	    else
 #endif
 #ifdef GNUTAR
-	    if (strcmp(est->dle->program, "GNUTAR") == 0)
+	    if (g_str_equal(est->dle->program, "GNUTAR"))
 		gnutar_calc_estimates(est);
 	    else
 #endif
@@ -1142,7 +1142,7 @@ generic_calc_estimates(
 	if (line[0] == '\0' || (int)strlen(line) <= len)
 	    continue;
 	/* Don't use sscanf for est->qamname because it can have a '%'. */
-	if (strncmp(line, est->qamname, len) == 0 &&
+	if (g_str_has_prefix(line, est->qamname) &&
 	    sscanf(line+len, match_expr, &level, &size_) == 2) {
 	    g_printf("%s\n", line); /* write to amandad */
 	    dbprintf(_("estimate size for %s level %d: %lld KB\n"),
@@ -1453,7 +1453,7 @@ getsize_dump(
 
 #ifdef XFSDUMP						/* { */
 #ifdef DUMP						/* { */
-    if (strcmp(fstype, "xfs") == 0)
+    if (g_str_equal(fstype, "xfs"))
 #else							/* } { */
     if (1)
 #endif							/* } */
@@ -1466,7 +1466,7 @@ getsize_dump(
 #endif							/* } */
 #ifdef VXDUMP						/* { */
 #ifdef DUMP						/* { */
-    if (strcmp(fstype, "vxfs") == 0)
+    if (g_str_equal(fstype, "vxfs"))
 #else							/* } { */
     if (1)
 #endif							/* } */
@@ -1488,7 +1488,7 @@ getsize_dump(
 #endif							/* } */
 #ifdef VDUMP						/* { */
 #ifdef DUMP						/* { */
-    if (strcmp(fstype, "advfs") == 0)
+    if (g_str_equal(fstype, "advfs"))
 #else							/* } { */
     if (1)
 #endif							/* } */
@@ -1632,7 +1632,7 @@ getsize_dump(
 
 #ifdef XFSDUMP
 #ifdef DUMP
-	if (strcmp(fstype, "xfs") == 0)
+	if (g_str_equal(fstype, "xfs"))
 #else
 	if (1)
 #endif
@@ -1646,7 +1646,7 @@ getsize_dump(
 #endif
 #ifdef VXDUMP
 #ifdef DUMP
-	if (strcmp(fstype, "vxfs") == 0)
+	if (g_str_equal(fstype, "vxfs"))
 #else
 	if (1)
 #endif
@@ -1660,7 +1660,7 @@ getsize_dump(
 #endif
 #ifdef VDUMP
 #ifdef DUMP
-	if (strcmp(fstype, "advfs") == 0)
+	if (g_str_equal(fstype, "advfs"))
 #else
 	if (1)
 #endif
@@ -2539,7 +2539,7 @@ getsize_application_api(
 	if (line[0] == '\0')
 	    continue;
 	dbprintf("%s\n", line);
-	if (strncmp(line,"ERROR ", 6) == 0) {
+	if (g_str_has_prefix(line, "ERROR ")) {
 	    char *errmsg, *qerrmsg;
 
 	    errmsg = g_strdup(line+6);

--- a/client-src/unctime.c
+++ b/client-src/unctime.c
@@ -85,7 +85,7 @@ lookup(
 	char *months = _("JanFebMarAprMayJunJulAugSepOctNovDec");
 
 	for (cp = months, cp2 = str; *cp != '\0'; cp += 3)
-		if (strncmp(cp, cp2, 3) == 0)
+		if (g_str_has_prefix(cp, cp2))
 			return ((int)(cp-months) / 3);
 	return -1;
 }

--- a/common-src/alloc.c
+++ b/common-src/alloc.c
@@ -174,8 +174,8 @@ safe_env_full(char **add)
 		p++;
 	    }
 	    for (env = environ; *env != NULL; env++) {
-		if (strncmp("LANG=", *env, 5) != 0 &&
-		    strncmp("LC_", *env, 3) != 0) {
+		if (!g_str_has_prefix("LANG=", *env) &&
+		    !g_str_has_prefix("LC_", *env)) {
 		    *p = g_strdup(*env);
 		    p++;
 		}

--- a/common-src/amanda.h
+++ b/common-src/amanda.h
@@ -651,7 +651,7 @@ time_t	unctime(char *timestr);
 
 /* (have to roll this up in an expression, so it can be used in if()) */
 #define strncmp_const_skip(str, cnst, ptr, var)				\
-	((strncmp((str), (cnst), sizeof((cnst))-1) == 0)?		\
+	((g_str_has_prefix((str), (cnst)))?		\
 		 ((ptr)+=sizeof((cnst))-1, (var)=(ptr)[-1], 0)		\
 		:1)
 

--- a/common-src/amfeatures.c
+++ b/common-src/amfeatures.c
@@ -420,7 +420,7 @@ am_string_to_feature(
     int				ch1, ch2;
     char *			orig = s;
 
-    if (s != NULL && strcmp(s,"UNKNOWNFEATURE") != 0) {
+    if (s != NULL && !g_str_equal(s, "UNKNOWNFEATURE")) {
 	f = am_allocate_feature_set();
 	for (i = 0; i < f->size && (ch1 = *s++) != '\0'; i++) {
 	    if (isdigit(ch1)) {

--- a/common-src/amservice.c
+++ b/common-src/amservice.c
@@ -263,7 +263,7 @@ handle_result(
 	} else {
 	    fprintf(stdout, "%s\n", line);
 	}
-	if (strncmp(line, "CONNECT ", 8) == 0) {
+	if (g_str_has_prefix(line, "CONNECT ")) {
 	    char *port = strchr(line, ' ');
 	    if (port) {
 		port = strchr(port+1, ' ');
@@ -271,7 +271,7 @@ handle_result(
 		    port_num = atoi(port+1);
 		}
 	    }
-	} else if (strncmp(line, "ERROR ", 6) == 0) {
+	} else if (g_str_has_prefix(line, "ERROR ")) {
 	    if (copy_stream) {
 		fprintf(stdout, "%s\n", line);
 	    }

--- a/common-src/amxml.c
+++ b/common-src/amxml.c
@@ -207,10 +207,10 @@ amstart_element(
 	for(at_names = attribute_names, at_values = attribute_values;
 	    *at_names != NULL && at_values != NULL;
 	    at_names++, at_values++) {
-	    if (strcmp(*at_names, "encoding") == 0) {
+	    if (g_str_equal(*at_names, "encoding")) {
 		amfree(data_user->encoding);
 		data_user->encoding = g_strdup(*at_values);
-	    } else if (strcmp(*at_names, "raw") == 0) {
+	    } else if (g_str_equal(*at_names, "raw")) {
 		amfree(data_user->raw);
 		data_user->raw = base64_decode_alloc_string((char *)*at_values);
 	    } else {
@@ -222,7 +222,7 @@ amstart_element(
 	}
     }
 
-    if (strcmp(element_name, "dle") == 0) {
+    if (g_str_equal(element_name, "dle")) {
 	if (last_element != NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid dle element");
@@ -257,72 +257,73 @@ amstart_element(
 	data_user->alevel = NULL;
 	amfree(data_user->encoding);
 	amfree(data_user->raw);
-    } else if(strcmp(element_name, "disk"          ) == 0 ||
-	      strcmp(element_name, "diskdevice"    ) == 0 ||
-	      strcmp(element_name, "calcsize"      ) == 0 ||
-	      strcmp(element_name, "estimate"      ) == 0 ||
-	      strcmp(element_name, "program"       ) == 0 ||
-	      strcmp(element_name, "auth"          ) == 0 ||
-	      strcmp(element_name, "index"         ) == 0 ||
-	      strcmp(element_name, "dumpdate"      ) == 0 ||
-	      strcmp(element_name, "level"         ) == 0 ||
-	      strcmp(element_name, "record"        ) == 0 ||
-	      strcmp(element_name, "spindle"       ) == 0 ||
-	      strcmp(element_name, "compress"      ) == 0 ||
-	      strcmp(element_name, "encrypt"       ) == 0 ||
-	      strcmp(element_name, "kencrypt"      ) == 0 ||
-	      strcmp(element_name, "datapath"      ) == 0 ||
-	      strcmp(element_name, "exclude"       ) == 0 ||
-	      strcmp(element_name, "include"       ) == 0) {
-	if (!last_element_name || strcmp(last_element_name, "dle") != 0) {
+    } else if(g_str_equal(element_name, "disk") ||
+	      g_str_equal(element_name, "diskdevice") ||
+	      g_str_equal(element_name, "calcsize") ||
+	      g_str_equal(element_name, "estimate") ||
+	      g_str_equal(element_name, "program") ||
+	      g_str_equal(element_name, "auth") ||
+	      g_str_equal(element_name, "index") ||
+	      g_str_equal(element_name, "dumpdate") ||
+	      g_str_equal(element_name, "level") ||
+	      g_str_equal(element_name, "record") ||
+	      g_str_equal(element_name, "spindle") ||
+	      g_str_equal(element_name, "compress") ||
+	      g_str_equal(element_name, "encrypt") ||
+	      g_str_equal(element_name, "kencrypt") ||
+	      g_str_equal(element_name, "datapath") ||
+	      g_str_equal(element_name, "exclude") ||
+	      g_str_equal(element_name, "include")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "dle")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
 	}
-	if ((strcmp(element_name, "disk"          ) == 0 && dle->disk) ||
-	    (strcmp(element_name, "diskdevice"    ) == 0 && dle->device) ||
-	    (strcmp(element_name, "calcsize"      ) == 0 && data_user->has_calcsize) ||
-	    (strcmp(element_name, "estimate"      ) == 0 && data_user->has_estimate) ||
-	    (strcmp(element_name, "record"        ) == 0 && data_user->has_record) ||
-	    (strcmp(element_name, "spindle"       ) == 0 && data_user->has_spindle) ||
-	    (strcmp(element_name, "program"       ) == 0 && dle->program) ||
-	    (strcmp(element_name, "auth"          ) == 0 && dle->auth) ||
-	    (strcmp(element_name, "index"         ) == 0 && data_user->has_index) ||
-	    (strcmp(element_name, "dumpdate"      ) == 0 && dle->dumpdate) ||
-	    (strcmp(element_name, "compress"      ) == 0 && data_user->has_compress) ||
-	    (strcmp(element_name, "encrypt"       ) == 0 && data_user->has_encrypt) ||
-	    (strcmp(element_name, "kencrypt"      ) == 0 && data_user->has_kencrypt) ||
-	    (strcmp(element_name, "datapath"      ) == 0 && data_user->has_datapath) ||
-	    (strcmp(element_name, "exclude"       ) == 0 && data_user->has_exclude) ||
-	    (strcmp(element_name, "include"       ) == 0 && data_user->has_include)) {
+	if ((g_str_equal(element_name, "disk") && dle->disk) ||
+	    (g_str_equal(element_name, "diskdevice") && dle->device) ||
+	    (g_str_equal(element_name, "calcsize") && data_user->has_calcsize) ||
+	    (g_str_equal(element_name, "estimate") && data_user->has_estimate) ||
+	    (g_str_equal(element_name, "record") && data_user->has_record) ||
+	    (g_str_equal(element_name, "spindle") && data_user->has_spindle) ||
+	    (g_str_equal(element_name, "program") && dle->program) ||
+	    (g_str_equal(element_name, "auth") && dle->auth) ||
+	    (g_str_equal(element_name, "index") && data_user->has_index) ||
+	    (g_str_equal(element_name, "dumpdate") && dle->dumpdate) ||
+	    (g_str_equal(element_name, "compress") && data_user->has_compress) ||
+	    (g_str_equal(element_name, "encrypt") && data_user->has_encrypt) ||
+	    (g_str_equal(element_name, "kencrypt") && data_user->has_kencrypt) ||
+	    (g_str_equal(element_name, "datapath") && data_user->has_datapath) ||
+	    (g_str_equal(element_name, "exclude") && data_user->has_exclude) ||
+	    (g_str_equal(element_name, "include") && data_user->has_include)) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Duplicate %s element", element_name);
 	    return;
 	}
-	if (strcmp(element_name, "calcsize"      ) == 0) data_user->has_calcsize       = 1;
-	if (strcmp(element_name, "estimate"      ) == 0) data_user->has_estimate       = 1;
-	if (strcmp(element_name, "record"        ) == 0) data_user->has_record         = 1;
-	if (strcmp(element_name, "spindle"       ) == 0) data_user->has_spindle        = 1;
-	if (strcmp(element_name, "index"         ) == 0) data_user->has_index          = 1;
-	if (strcmp(element_name, "compress"      ) == 0) data_user->has_compress       = 1;
-	if (strcmp(element_name, "encrypt"       ) == 0) data_user->has_encrypt        = 1;
-	if (strcmp(element_name, "kencrypt"      ) == 0) data_user->has_kencrypt       = 1;
-	if (strcmp(element_name, "datapath"      ) == 0) data_user->has_datapath       = 1;
-	if (strcmp(element_name, "exclude"       ) == 0) data_user->has_exclude        = 1;
-	if (strcmp(element_name, "include"       ) == 0) data_user->has_include        = 1;
-	if (strcmp(element_name, "exclude") == 0 || strcmp(element_name, "include") == 0)
+	if (g_str_equal(element_name, "calcsize")) data_user->has_calcsize       = 1;
+	if (g_str_equal(element_name, "estimate")) data_user->has_estimate       = 1;
+	if (g_str_equal(element_name, "record")) data_user->has_record         = 1;
+	if (g_str_equal(element_name, "spindle")) data_user->has_spindle        = 1;
+	if (g_str_equal(element_name, "index")) data_user->has_index          = 1;
+	if (g_str_equal(element_name, "compress")) data_user->has_compress       = 1;
+	if (g_str_equal(element_name, "encrypt")) data_user->has_encrypt        = 1;
+	if (g_str_equal(element_name, "kencrypt")) data_user->has_kencrypt       = 1;
+	if (g_str_equal(element_name, "datapath")) data_user->has_datapath       = 1;
+	if (g_str_equal(element_name, "exclude")) data_user->has_exclude        = 1;
+	if (g_str_equal(element_name, "include")) data_user->has_include        = 1;
+	if (g_str_equal(element_name, "exclude") || g_str_equal(element_name,
+                                                                "include"))
 	   data_user->has_optional = 0;
-	if (strcmp(element_name, "level") == 0) {
+	if (g_str_equal(element_name, "level")) {
 	    data_user->alevel = g_new0(level_t, 1);
 	}
-    } else if (strcmp(element_name, "server") == 0) {
-	if (!last_element_name || strcmp(last_element_name, "level") != 0) {
+    } else if (g_str_equal(element_name, "server")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "level")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
 	}
-    } else if(strcmp(element_name, "custom-compress-program") == 0) {
-	if (!last_element_name || strcmp(last_element_name, "compress") != 0) {
+    } else if(g_str_equal(element_name, "custom-compress-program")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "compress")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
@@ -332,29 +333,29 @@ amstart_element(
 			"XML: Duplicate %s element", element_name);
 	    return;
 	}
-    } else if (strcmp(element_name, "custom-encrypt-program") == 0 ||
-	       strcmp(element_name, "decrypt-option") == 0) {
-	if (!last_element_name || strcmp(last_element_name, "encrypt") != 0) {
+    } else if (g_str_equal(element_name, "custom-encrypt-program") ||
+	       g_str_equal(element_name, "decrypt-option")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "encrypt")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
 	}
-	if (strcmp(element_name, "custom-encrypt-program") == 0 &&
+	if (g_str_equal(element_name, "custom-encrypt-program") &&
 		   dle->clnt_encrypt) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Duplicate %s element", element_name);
 	    return;
 	}
-	if (strcmp(element_name, "decrypt-option") == 0 &&
+	if (g_str_equal(element_name, "decrypt-option") &&
 		   dle->clnt_decrypt_opt) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Duplicate %s element", element_name);
 	    return;
 	}
-    } else if(strcmp(element_name, "plugin") == 0) {
+    } else if(g_str_equal(element_name, "plugin")) {
 	if (!last_element_name ||
-	    (strcmp(last_element_name, "backup-program") != 0 &&
-	     strcmp(last_element_name, "script") != 0)) {
+	    (!g_str_equal(last_element_name, "backup-program") &&
+	     !g_str_equal(last_element_name, "script"))) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
@@ -365,10 +366,10 @@ amstart_element(
 			last_element_name);
 	    return;
 	}
-    } else if(strcmp(element_name, "property") == 0) {
+    } else if(g_str_equal(element_name, "property")) {
 	if (!last_element_name ||
-	    (strcmp(last_element_name, "backup-program") != 0 &&
-	     strcmp(last_element_name, "script") != 0)) {
+	    (!g_str_equal(last_element_name, "backup-program") &&
+	     !g_str_equal(last_element_name, "script"))) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
@@ -377,8 +378,8 @@ amstart_element(
 	data_user->property_data->append = 0;
 	data_user->property_data->priority = 0;
 	data_user->property_data->values = NULL;
-    } else if(strcmp(element_name, "name") == 0) {
-	if (!last_element_name || strcmp(last_element_name, "property") != 0) {
+    } else if(g_str_equal(element_name, "name")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "property")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
@@ -389,35 +390,35 @@ amstart_element(
 			last_element_name);
 	    return;
 	}
-    } else if(strcmp(element_name, "priority") == 0) {
-	if (!last_element_name || strcmp(last_element_name, "property") != 0) {
+    } else if(g_str_equal(element_name, "priority")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "property")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
 	}
-    } else if(strcmp(element_name, "value") == 0) {
-	if (!last_element_name || strcmp(last_element_name, "property") != 0) {
+    } else if(g_str_equal(element_name, "value")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "property")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
 	}
-    } else if(strcmp(element_name, "file") == 0 ||
-	      strcmp(element_name, "list") == 0 ||
-	      strcmp(element_name, "optional") == 0) {
+    } else if(g_str_equal(element_name, "file") ||
+	      g_str_equal(element_name, "list") ||
+	      g_str_equal(element_name, "optional")) {
 	if (!last_element_name ||
-	    (strcmp(last_element_name, "exclude") != 0 &&
-	     strcmp(last_element_name, "include") != 0)) {
+	    (!g_str_equal(last_element_name, "exclude") &&
+	     !g_str_equal(last_element_name, "include"))) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
 	}
-	if (strcmp(element_name, "optional") == 0 && data_user->has_optional) {
+	if (g_str_equal(element_name, "optional") && data_user->has_optional) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Duplicate %s element", element_name);
 	    return;
 	}
-	if (strcmp(element_name, "optional") == 0) data_user->has_optional = 1;
-    } else if (strcmp(element_name, "backup-program") == 0) {
+	if (g_str_equal(element_name, "optional")) data_user->has_optional = 1;
+    } else if (g_str_equal(element_name, "backup-program")) {
 	if (data_user->has_backup_program) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Duplicate %s element", element_name);
@@ -428,7 +429,7 @@ amstart_element(
 	            g_hash_table_new_full(g_str_hash, g_str_equal, &g_free, &free_property_t);
 	    data_user->has_plugin = 0;
 	}
-    } else if (strcmp(element_name, "script") == 0) {
+    } else if (g_str_equal(element_name, "script")) {
 	data_user->property =
 	            g_hash_table_new_full(g_str_hash, g_str_equal, &g_free, &free_property_t);
 	data_user->script = malloc(sizeof(script_t));
@@ -439,15 +440,15 @@ amstart_element(
 	data_user->script->client_name = NULL;
 	data_user->script->result = NULL;
 	data_user->has_plugin = 0;
-    } else if (strcmp(element_name, "execute_on") == 0) {
-    } else if (strcmp(element_name, "execute_where") == 0) {
-    } else if (strcmp(element_name, "directtcp") == 0) {
-	if (!last_element_name || strcmp(last_element_name, "datapath") != 0) {
+    } else if (g_str_equal(element_name, "execute_on")) {
+    } else if (g_str_equal(element_name, "execute_where")) {
+    } else if (g_str_equal(element_name, "directtcp")) {
+	if (!last_element_name || !g_str_equal(last_element_name, "datapath")) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: Invalid %s element", element_name);
 	    return;
 	}
-    } else if (strcmp(element_name, "client_name") == 0) {
+    } else if (g_str_equal(element_name, "client_name")) {
     } else {
 	g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 		    "XML: Invalid %s element", element_name);
@@ -476,19 +477,19 @@ amend_element(
 	return;
     }
     last_element_name = last_element->data;
-    if (strcmp(last_element_name, element_name) != 0) {
+    if (!g_str_equal(last_element_name, element_name)) {
 	g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 		    "XML: Invalid closing tag '%s'", element_name);
 	return;
     }
 
-    if (strcmp(element_name, "property") == 0) {
+    if (g_str_equal(element_name, "property")) {
 	g_hash_table_insert(data_user->property,
 			    data_user->property_name,
 			    data_user->property_data);
 	data_user->property_name = NULL;
 	data_user->property_data = NULL;
-    } else if (strcmp(element_name, "dle") == 0) {
+    } else if (g_str_equal(element_name, "dle")) {
 	if (dle->program_is_application_api &&
 	    !dle->program) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
@@ -501,7 +502,7 @@ amend_element(
 	    dle->estimatelist = g_slist_append(dle->estimatelist, ES_CLIENT);
 /* Add check of required field */
 	data_user->dle = NULL;
-    } else if (strcmp(element_name, "backup-program") == 0) {
+    } else if (g_str_equal(element_name, "backup-program")) {
 	if (dle->program == NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 		    "XML: No plugin set for application");
@@ -509,7 +510,7 @@ amend_element(
 	}
 	dle->application_property = data_user->property;
 	data_user->property = NULL;
-    } else if (strcmp(element_name, "script") == 0) {
+    } else if (g_str_equal(element_name, "script")) {
 	if (data_user->script->plugin == NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 		    "XML: No plugin set for script");
@@ -519,7 +520,7 @@ amend_element(
 	data_user->property = NULL;
 	dle->scriptlist = g_slist_append(dle->scriptlist, data_user->script);
 	data_user->script = NULL;
-    } else if (strcmp(element_name, "level") == 0) {
+    } else if (g_str_equal(element_name, "level")) {
 	dle->levellist = g_slist_append(dle->levellist, data_user->alevel);
 	data_user->alevel = NULL;
     }
@@ -583,15 +584,15 @@ amtext(
 	return;
     }
 
-    if (strcmp(last_element_name, "dle") == 0 ||
-	strcmp(last_element_name, "backup-program") == 0 ||
-	strcmp(last_element_name, "exclude") == 0 ||
-	strcmp(last_element_name, "include") == 0) {
+    if (g_str_equal(last_element_name, "dle") ||
+	g_str_equal(last_element_name, "backup-program") ||
+	g_str_equal(last_element_name, "exclude") ||
+	g_str_equal(last_element_name, "include")) {
 	g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 		    "XML: %s doesn't have text '%s'", last_element_name, tt);
 	amfree(tt);
 	return;
-    } else if(strcmp(last_element_name, "disk") == 0) {
+    } else if(g_str_equal(last_element_name, "disk")) {
 	if (dle->disk != NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: multiple text in %s", last_element_name);
@@ -599,7 +600,7 @@ amtext(
 	    return;
 	}
 	dle->disk = tt;
-    } else if(strcmp(last_element_name, "diskdevice") == 0) {
+    } else if(g_str_equal(last_element_name, "diskdevice")) {
 	if (dle->device != NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: multiple text in %s", last_element_name);
@@ -607,13 +608,13 @@ amtext(
 	    return;
 	}
 	dle->device = tt;
-    } else if(strcmp(last_element_name, "calcsize") == 0) {
+    } else if(g_str_equal(last_element_name, "calcsize")) {
 	if (strcasecmp(tt,"yes") == 0) {
 	    dle->estimatelist = g_slist_append(dle->estimatelist,
 					       GINT_TO_POINTER(ES_CALCSIZE));
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "estimate") == 0) {
+    } else if(g_str_equal(last_element_name, "estimate")) {
 	char *ttt = tt;
 	while (strlen(ttt) > 0) {
 	    if (BSTRNCMP(ttt,"CLIENT") == 0) {
@@ -638,52 +639,52 @@ amtext(
 		ttt++;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "program") == 0) {
+    } else if(g_str_equal(last_element_name, "program")) {
 	if (dle->program != NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: multiple text in %s", last_element_name);
 	    amfree(tt);
 	    return;
 	}
-	if (strcmp(tt, "APPLICATION") == 0) {
+	if (g_str_equal(tt, "APPLICATION")) {
 	    dle->program_is_application_api = 1;
 	    dle->program = NULL;
 	    amfree(tt);
 	} else {
 	    dle->program = tt;
 	}
-    } else if(strcmp(last_element_name, "plugin") == 0) {
+    } else if(g_str_equal(last_element_name, "plugin")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("Invalid name text");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "backup-program") == 0) {
+	if (g_str_equal(last_element2_name, "backup-program")) {
 	    dle->program = tt;
-	} else if (strcmp(last_element2_name, "script") == 0) {
+	} else if (g_str_equal(last_element2_name, "script")) {
 	    data_user->script->plugin = tt;
 	} else {
 	    error("plugin outside of backup-program");
 	}
 	data_user->has_plugin = 1;
-    } else if(strcmp(last_element_name, "name") == 0) {
+    } else if(g_str_equal(last_element_name, "name")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("Invalid name text");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "property") == 0) {
+	if (g_str_equal(last_element2_name, "property")) {
 	    data_user->property_name = tt;
 	} else {
 	    error("name outside of property");
 	}
-    } else if(strcmp(last_element_name, "priority") == 0) {
+    } else if(g_str_equal(last_element_name, "priority")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("Invalid priority text");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "property") == 0) {
+	if (g_str_equal(last_element2_name, "property")) {
 	    if (strcasecmp(tt,"yes") == 0) {
 		data_user->property_data->priority = 1;
 	    }
@@ -691,29 +692,29 @@ amtext(
 	    error("priority outside of property");
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "value") == 0) {
+    } else if(g_str_equal(last_element_name, "value")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("Invalid name text");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "property") == 0) {
+	if (g_str_equal(last_element2_name, "property")) {
 	    data_user->property_data->values =
 			g_slist_append(data_user->property_data->values, tt);
 	} else {
 	    error("value outside of property");
 	}
-    } else if(strcmp(last_element_name, "auth") == 0) {
+    } else if(g_str_equal(last_element_name, "auth")) {
 	if (dle->auth != NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: multiple text in %s", last_element_name);
 	    return;
 	}
 	dle->auth = tt;
-    } else if(strcmp(last_element_name, "level") == 0) {
+    } else if(g_str_equal(last_element_name, "level")) {
 	data_user->alevel->level = atoi(tt);
 	amfree(tt);
-    } else if (strcmp(last_element_name, "server") == 0) {
+    } else if (g_str_equal(last_element_name, "server")) {
 	if (strcasecmp(tt,"no") == 0) {
 	    data_user->alevel->server = 0;
 	} else if (strcasecmp(tt,"yes") == 0) {
@@ -725,7 +726,7 @@ amtext(
 	    return;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "index") == 0) {
+    } else if(g_str_equal(last_element_name, "index")) {
 	if (strcasecmp(tt,"no") == 0) {
 	    dle->create_index = 0;
 	} else if (strcasecmp(tt,"yes") == 0) {
@@ -737,7 +738,7 @@ amtext(
 	    return;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "dumpdate") == 0) {
+    } else if(g_str_equal(last_element_name, "dumpdate")) {
 	if (dle->dumpdate != NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: multiple text in %s", last_element_name);
@@ -745,7 +746,7 @@ amtext(
 	    return;
 	}
 	dle->dumpdate = tt;
-    } else if(strcmp(last_element_name, "record") == 0) {
+    } else if(g_str_equal(last_element_name, "record")) {
 	if (strcasecmp(tt, "no") == 0) {
 	    dle->record = 0;
 	} else if (strcasecmp(tt, "yes") == 0) {
@@ -757,19 +758,19 @@ amtext(
 	    return;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "spindle") == 0) {
+    } else if(g_str_equal(last_element_name, "spindle")) {
 	dle->spindle = atoi(tt);
 	amfree(tt);
-    } else if(strcmp(last_element_name, "compress") == 0) {
-	if (strcmp(tt, "FAST") == 0) {
+    } else if(g_str_equal(last_element_name, "compress")) {
+	if (g_str_equal(tt, "FAST")) {
 	    dle->compress = COMP_FAST;
-	} else if (strcmp(tt, "BEST") == 0) {
+	} else if (g_str_equal(tt, "BEST")) {
 	    dle->compress = COMP_BEST;
 	} else if (BSTRNCMP(tt, "CUSTOM") == 0) {
 	    dle->compress = COMP_CUST;
-	} else if (strcmp(tt, "SERVER-FAST") == 0) {
+	} else if (g_str_equal(tt, "SERVER-FAST")) {
 	    dle->compress = COMP_SERVER_FAST;
-	} else if (strcmp(tt, "SERVER-BEST") == 0) {
+	} else if (g_str_equal(tt, "SERVER-BEST")) {
 	    dle->compress = COMP_SERVER_BEST;
 	} else if (BSTRNCMP(tt, "SERVER-CUSTOM") == 0) {
 	    dle->compress = COMP_SERVER_CUST;
@@ -780,7 +781,7 @@ amtext(
 	    return;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "custom-compress-program") == 0) {
+    } else if(g_str_equal(last_element_name, "custom-compress-program")) {
 	if (dle->compprog != NULL) {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: multiple text in %s", last_element_name);
@@ -788,7 +789,7 @@ amtext(
 	    return;
 	}
 	dle->compprog = tt;
-    } else if(strcmp(last_element_name, "encrypt") == 0) {
+    } else if(g_str_equal(last_element_name, "encrypt")) {
 	if (BSTRNCMP(tt,"NO") == 0) {
 	    dle->encrypt = ENCRYPT_NONE;
 	} else if (BSTRNCMP(tt, "CUSTOM") == 0) {
@@ -802,7 +803,7 @@ amtext(
 	    return;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "kencrypt") == 0) {
+    } else if(g_str_equal(last_element_name, "kencrypt")) {
 	if (strcasecmp(tt,"no") == 0) {
 	    dle->kencrypt = 0;
 	} else if (strcasecmp(tt,"yes") == 0) {
@@ -814,7 +815,7 @@ amtext(
 	    return;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "custom-encrypt-program") == 0) {
+    } else if(g_str_equal(last_element_name, "custom-encrypt-program")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("XML: optional");
@@ -824,7 +825,7 @@ amtext(
 	    dle->srv_encrypt = tt;
 	else
 	    dle->clnt_encrypt = tt;
-    } else if(strcmp(last_element_name, "decrypt-option") == 0) {
+    } else if(g_str_equal(last_element_name, "decrypt-option")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("XML: optional");
@@ -834,106 +835,106 @@ amtext(
 	    dle->srv_decrypt_opt = tt;
 	else
 	    dle->clnt_decrypt_opt = tt;
-    } else if(strcmp(last_element_name, "exclude") == 0 ||
-	      strcmp(last_element_name, "include") == 0) {
+    } else if(g_str_equal(last_element_name, "exclude") ||
+	      g_str_equal(last_element_name, "include")) {
 	data_user->has_optional = 0;
 	amfree(tt);
-    } else if(strcmp(last_element_name, "file") == 0) {
+    } else if(g_str_equal(last_element_name, "file")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("XML: optional");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "exclude") == 0) {
+	if (g_str_equal(last_element2_name, "exclude")) {
 	    dle->exclude_file = append_sl(dle->exclude_file, tt);
-	} else if (strcmp(last_element2_name, "include") == 0) {
+	} else if (g_str_equal(last_element2_name, "include")) {
 	    dle->include_file = append_sl(dle->include_file, tt);
 	} else {
 	    error("bad file");
 	}
-    } else if(strcmp(last_element_name, "list") == 0) {
+    } else if(g_str_equal(last_element_name, "list")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("XML: optional");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "exclude") == 0) {
+	if (g_str_equal(last_element2_name, "exclude")) {
 	    dle->exclude_list = append_sl(dle->exclude_list, tt);
-	} else if (strcmp(last_element2_name, "include") == 0) {
+	} else if (g_str_equal(last_element2_name, "include")) {
 	    dle->include_list = append_sl(dle->include_list, tt);
 	} else {
 	    error("bad list");
 	}
-    } else if(strcmp(last_element_name, "optional") == 0) {
+    } else if(g_str_equal(last_element_name, "optional")) {
 	i = atoi(tt);
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("XML: optional");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "exclude") == 0) {
+	if (g_str_equal(last_element2_name, "exclude")) {
 	    dle->exclude_optional = 1;
-	} else if (strcmp(last_element2_name, "include") == 0) {
+	} else if (g_str_equal(last_element2_name, "include")) {
 	    dle->include_optional = 1;
 	} else {
 	    error("bad optional");
 	}
 	data_user->has_optional = 1;
 	amfree(tt);
-    } else if(strcmp(last_element_name, "script") == 0) {
+    } else if(g_str_equal(last_element_name, "script")) {
 	amfree(tt);
-    } else if(strcmp(last_element_name, "execute_on") == 0) {
+    } else if(g_str_equal(last_element_name, "execute_on")) {
 	char *sep;
 	char *tt1 = tt;
 	do {
 	    sep = strchr(tt1,',');
 	    if (sep)
 		*sep = '\0';
-	    if (strcmp(tt1,"PRE-AMCHECK") == 0)
+	    if (g_str_equal(tt1, "PRE-AMCHECK"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_AMCHECK;
-	    else if (strcmp(tt1,"PRE-DLE-AMCHECK") == 0)
+	    else if (g_str_equal(tt1, "PRE-DLE-AMCHECK"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_DLE_AMCHECK;
-	    else if (strcmp(tt1,"PRE-HOST-AMCHECK") == 0)
+	    else if (g_str_equal(tt1, "PRE-HOST-AMCHECK"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_HOST_AMCHECK;
-	    else if (strcmp(tt1,"POST-AMCHECK") == 0)
+	    else if (g_str_equal(tt1, "POST-AMCHECK"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_AMCHECK;
-	    else if (strcmp(tt1,"POST-DLE-AMCHECK") == 0)
+	    else if (g_str_equal(tt1, "POST-DLE-AMCHECK"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_DLE_AMCHECK;
-	    else if (strcmp(tt1,"POST-HOST-AMCHECK") == 0)
+	    else if (g_str_equal(tt1, "POST-HOST-AMCHECK"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_HOST_AMCHECK;
-	    else if (strcmp(tt1,"PRE-ESTIMATE") == 0)
+	    else if (g_str_equal(tt1, "PRE-ESTIMATE"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_ESTIMATE;
-	    else if (strcmp(tt1,"PRE-DLE-ESTIMATE") == 0)
+	    else if (g_str_equal(tt1, "PRE-DLE-ESTIMATE"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_DLE_ESTIMATE;
-	    else if (strcmp(tt1,"PRE-HOST-ESTIMATE") == 0)
+	    else if (g_str_equal(tt1, "PRE-HOST-ESTIMATE"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_HOST_ESTIMATE;
-	    else if (strcmp(tt1,"POST-ESTIMATE") == 0)
+	    else if (g_str_equal(tt1, "POST-ESTIMATE"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_ESTIMATE;
-	    else if (strcmp(tt1,"POST-DLE-ESTIMATE") == 0)
+	    else if (g_str_equal(tt1, "POST-DLE-ESTIMATE"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_DLE_ESTIMATE;
-	    else if (strcmp(tt1,"POST-HOST-ESTIMATE") == 0)
+	    else if (g_str_equal(tt1, "POST-HOST-ESTIMATE"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_HOST_ESTIMATE;
-	    else if (strcmp(tt1,"PRE-BACKUP") == 0)
+	    else if (g_str_equal(tt1, "PRE-BACKUP"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_BACKUP;
-	    else if (strcmp(tt1,"PRE-DLE-BACKUP") == 0)
+	    else if (g_str_equal(tt1, "PRE-DLE-BACKUP"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_DLE_BACKUP;
-	    else if (strcmp(tt1,"PRE-HOST-BACKUP") == 0)
+	    else if (g_str_equal(tt1, "PRE-HOST-BACKUP"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_HOST_BACKUP;
-	    else if (strcmp(tt1,"POST-BACKUP") == 0)
+	    else if (g_str_equal(tt1, "POST-BACKUP"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_BACKUP;
-	    else if (strcmp(tt1,"POST-DLE-BACKUP") == 0)
+	    else if (g_str_equal(tt1, "POST-DLE-BACKUP"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_DLE_BACKUP;
-	    else if (strcmp(tt1,"POST-HOST-BACKUP") == 0)
+	    else if (g_str_equal(tt1, "POST-HOST-BACKUP"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_HOST_BACKUP;
-	    else if (strcmp(tt1,"PRE-RECOVER") == 0)
+	    else if (g_str_equal(tt1, "PRE-RECOVER"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_RECOVER;
-	    else if (strcmp(tt1,"POST-RECOVER") == 0)
+	    else if (g_str_equal(tt1, "POST-RECOVER"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_RECOVER;
-	    else if (strcmp(tt1,"PRE-LEVEL-RECOVER") == 0)
+	    else if (g_str_equal(tt1, "PRE-LEVEL-RECOVER"))
 		data_user->script->execute_on |= EXECUTE_ON_PRE_LEVEL_RECOVER;
-	    else if (strcmp(tt1,"POST-LEVEL-RECOVER") == 0)
+	    else if (g_str_equal(tt1, "POST-LEVEL-RECOVER"))
 		data_user->script->execute_on |= EXECUTE_ON_POST_LEVEL_RECOVER;
-	    else if (strcmp(tt1,"INTER-LEVEL-RECOVER") == 0)
+	    else if (g_str_equal(tt1, "INTER-LEVEL-RECOVER"))
 		data_user->script->execute_on |= EXECUTE_ON_INTER_LEVEL_RECOVER;
 	    else 
 		dbprintf("BAD EXECUTE_ON: %s\n", tt1);
@@ -941,35 +942,35 @@ amtext(
 		tt1 = sep+1;
 	} while (sep);
 	amfree(tt);
-    } else if(strcmp(last_element_name, "execute_where") == 0) {
-	if (strcmp(tt, "CLIENT") == 0) {
+    } else if(g_str_equal(last_element_name, "execute_where")) {
+	if (g_str_equal(tt, "CLIENT")) {
 	    data_user->script->execute_where = ES_CLIENT;
 	} else {
 	    data_user->script->execute_where = ES_SERVER;
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "datapath") == 0) {
-	if (strcmp(tt, "AMANDA") == 0) {
+    } else if(g_str_equal(last_element_name, "datapath")) {
+	if (g_str_equal(tt, "AMANDA")) {
 	    dle->data_path = DATA_PATH_AMANDA;
-	} else if (strcmp(tt, "DIRECTTCP") == 0) {
+	} else if (g_str_equal(tt, "DIRECTTCP")) {
 	    dle->data_path = DATA_PATH_DIRECTTCP;
 	} else {
 	    g_set_error(gerror, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
 			"XML: bad datapath value '%s'", tt);
 	}
 	amfree(tt);
-    } else if(strcmp(last_element_name, "directtcp") == 0) {
+    } else if(g_str_equal(last_element_name, "directtcp")) {
 	dle->directtcp_list = g_slist_append(dle->directtcp_list, tt);
-    } else if(strcmp(last_element_name, "client_name") == 0) {
+    } else if(g_str_equal(last_element_name, "client_name")) {
 	last_element2 = g_slist_nth(data_user->element_names, 1);
 	if (!last_element2) {
 	    error("Invalid client_name text");
 	}
 	last_element2_name = last_element2->data;
-	if (strcmp(last_element2_name, "backup-program") == 0) {
+	if (g_str_equal(last_element2_name, "backup-program")) {
 	    dle->application_client_name = tt;
 g_debug("set dle->application_client_name: %s", dle->application_client_name);
-	} else if (strcmp(last_element2_name, "script") == 0) {
+	} else if (g_str_equal(last_element2_name, "script")) {
 	    data_user->script->client_name = tt;
 g_debug("set data_user->script->client_name: %s", data_user->script->client_name);
 	} else {

--- a/common-src/conffile.c
+++ b/common-src/conffile.c
@@ -2018,7 +2018,7 @@ get_seen_filename(
 
     for (iter = seen_filenames; iter; iter = iter->next) {
 	istr = iter->data;
-	if (istr == filename || 0 == strcmp(istr, filename))
+	if (istr == filename || g_str_equal(istr, filename))
 	    return istr;
     }
 
@@ -2203,7 +2203,7 @@ get_holdingdisk(
 
 	    for (il = conf_data[CNF_HOLDINGDISK].v.identlist; il != NULL;
 							      il = il->next) {
-		if (strcmp((char *)il->data, hdcur.name) == 0) {
+		if (g_str_equal((char *)il->data, hdcur.name)) {
 		    break;
 		}
 	    }
@@ -5107,7 +5107,7 @@ static void validate_one_columnspec(const char *element)
     token = g_ascii_strdown(element, -1);
 
     for (i = 0; i < nr_valid_names; i++)
-        if (!strcmp(colspec_valid_names[i], token)) /* We have a match */
+        if (g_str_equal(colspec_valid_names[i], token)) /* We have a match */
             break;
 
     g_free(token);
@@ -5196,7 +5196,7 @@ config_init(
     /* if we're using an explicit name, but the name is '.', then we're using the
      * current directory */
     if ((flags & CONFIG_INIT_EXPLICIT_NAME) && arg_config_name) {
-	if (0 == strcmp(arg_config_name, "."))
+	if (g_str_equal(arg_config_name, "."))
 	    flags = (flags & (~CONFIG_INIT_EXPLICIT_NAME)) | CONFIG_INIT_USE_CWD;
     }
 
@@ -5695,7 +5695,7 @@ update_derived_values(
 	    /* Create a default tapetype so that other code has
 	     * something to refer to, but don't pretend it's real */
 	    if (!getconf_seen(CNF_TAPETYPE) &&
-		strcmp(getconf_str(CNF_TAPETYPE), "DEFAULT_TAPE") == 0 &&
+		g_str_equal(getconf_str(CNF_TAPETYPE), "DEFAULT_TAPE") &&
 		!lookup_tapetype("DEFAULT_TAPE")) {
 		init_tapetype_defaults();
 		tpcur.name = g_strdup("DEFAULT_TAPE");
@@ -6250,10 +6250,10 @@ validate_program(
     conf_var_t *np G_GNUC_UNUSED,
     val_t        *val)
 {
-    if (strcmp(val->v.s, "DUMP") != 0 &&
-    	strcmp(val->v.s, "GNUTAR") != 0 &&
-    	strcmp(val->v.s, "STAR") != 0 &&
-    	strcmp(val->v.s, "APPLICATION") != 0)
+    if (!g_str_equal(val->v.s, "DUMP") &&
+    	!g_str_equal(val->v.s, "GNUTAR") &&
+    	!g_str_equal(val->v.s, "STAR") &&
+    	!g_str_equal(val->v.s, "APPLICATION"))
        conf_parserror("program must be \"DUMP\", \"GNUTAR\", \"STAR\" or \"APPLICATION\"");
 }
 
@@ -6645,7 +6645,7 @@ extract_commandline_config_overrides(
 
     i = 0;
     while (i<*argc) {
-	if(strncmp((*argv)[i],"-o",2) == 0) {
+	if(g_str_has_prefix((*argv)[i], "-o")) {
 	    if(strlen((*argv)[i]) > 2) {
 		add_config_override_opt(co, (*argv)[i]+2);
 		moveup = 1;
@@ -7340,9 +7340,9 @@ generic_get_security_conf(
 	if(!string || !*string)
 		return(NULL);
 
-	if(strcmp(string, "krb5principal")==0) {
+	if(g_str_equal(string, "krb5principal")) {
 		return(getconf_str(CNF_KRB5PRINCIPAL));
-	} else if(strcmp(string, "krb5keytab")==0) {
+	} else if(g_str_equal(string, "krb5keytab")) {
 		return(getconf_str(CNF_KRB5KEYTAB));
 	}
 	return(NULL);
@@ -7358,33 +7358,33 @@ generic_client_get_security_conf(
 	if(!string || !*string)
 		return(NULL);
 
-	if(strcmp(string, "conf")==0) {
+	if(g_str_equal(string, "conf")) {
 		return(getconf_str(CNF_CONF));
-	} else if(strcmp(string, "amdump_server")==0) {
+	} else if(g_str_equal(string, "amdump_server")) {
 		return(getconf_str(CNF_AMDUMP_SERVER));
-	} else if(strcmp(string, "index_server")==0) {
+	} else if(g_str_equal(string, "index_server")) {
 		return(getconf_str(CNF_INDEX_SERVER));
-	} else if(strcmp(string, "tape_server")==0) {
+	} else if(g_str_equal(string, "tape_server")) {
 		return(getconf_str(CNF_TAPE_SERVER));
-	} else if(strcmp(string, "tapedev")==0) {
+	} else if(g_str_equal(string, "tapedev")) {
 		return(getconf_str(CNF_TAPEDEV));
-        } else if(strcmp(string, "auth")==0) {
+        } else if(g_str_equal(string, "auth")) {
 		return(getconf_str(CNF_AUTH));
-	} else if(strcmp(string, "ssh_keys")==0) {
+	} else if(g_str_equal(string, "ssh_keys")) {
 		return(getconf_str(CNF_SSH_KEYS));
-	} else if(strcmp(string, "amandad_path")==0) {
+	} else if(g_str_equal(string, "amandad_path")) {
 		return(getconf_str(CNF_AMANDAD_PATH));
-	} else if(strcmp(string, "client_username")==0) {
+	} else if(g_str_equal(string, "client_username")) {
 		return(getconf_str(CNF_CLIENT_USERNAME));
-	} else if(strcmp(string, "client_port")==0) {
+	} else if(g_str_equal(string, "client_port")) {
 		return(getconf_str(CNF_CLIENT_PORT));
-	} else if(strcmp(string, "gnutar_list_dir")==0) {
+	} else if(g_str_equal(string, "gnutar_list_dir")) {
 		return(getconf_str(CNF_GNUTAR_LIST_DIR));
-	} else if(strcmp(string, "amandates")==0) {
+	} else if(g_str_equal(string, "amandates")) {
 		return(getconf_str(CNF_AMANDATES));
-	} else if(strcmp(string, "krb5principal")==0) {
+	} else if(g_str_equal(string, "krb5principal")) {
 		return(getconf_str(CNF_KRB5PRINCIPAL));
-	} else if(strcmp(string, "krb5keytab")==0) {
+	} else if(g_str_equal(string, "krb5keytab")) {
 		return(getconf_str(CNF_KRB5KEYTAB));
 	}
 	return(NULL);
@@ -7499,7 +7499,7 @@ dump_configuration(void)
 	seen_t *netusage_seen = &val_t__seen(getconf(CNF_NETUSAGE));
 	if (ip->seen.linenum == netusage_seen->linenum &&
 	    ip->seen.filename && netusage_seen->filename &&
-	    0 == strcmp(ip->seen.filename, netusage_seen->filename))
+	    g_str_equal(ip->seen.filename, netusage_seen->filename))
 	    prefix = "#";
 	else
 	    prefix = "";
@@ -7521,7 +7521,7 @@ dump_configuration(void)
     }
 
     for(ap = application_list; ap != NULL; ap = ap->next) {
-	if(strcmp(ap->name,"default") == 0)
+	if(g_str_equal(ap->name, "default"))
 	    prefix = "#";
 	else
 	    prefix = "";
@@ -7543,7 +7543,7 @@ dump_configuration(void)
     }
 
     for(ps = pp_script_list; ps != NULL; ps = ps->next) {
-	if(strcmp(ps->name,"default") == 0)
+	if(g_str_equal(ps->name, "default"))
 	    prefix = "#";
 	else
 	    prefix = "";
@@ -8242,14 +8242,14 @@ parm_key_info(
 	/* If the keyword doesn't exist, there's no need to look up the
 	 * subsection -- we know it's invalid */
 	for(kt = keytable; kt->token != CONF_UNKNOWN; kt++) {
-	    if(kt->keyword && strcmp(kt->keyword, subsec_key) == 0)
+	    if(kt->keyword && g_str_equal(kt->keyword, subsec_key))
 		break;
 	}
 	if(kt->token == CONF_UNKNOWN) goto out;
 
 	/* Otherwise, figure out which kind of subsection we're dealing with,
 	 * and parse against that. */
-	if (strcmp(subsec_type, "TAPETYPE") == 0) {
+	if (g_str_equal(subsec_type, "TAPETYPE")) {
 	    tp = lookup_tapetype(subsec_name);
 	    if (!tp) goto out;
 	    for(np = tapetype_var; np->token != CONF_UNKNOWN; np++) {
@@ -8261,7 +8261,7 @@ parm_key_info(
 	    if (val) *val = &tp->value[np->parm];
 	    if (parm) *parm = np;
 	    success = TRUE;
-	} else if (strcmp(subsec_type, "DUMPTYPE") == 0) {
+	} else if (g_str_equal(subsec_type, "DUMPTYPE")) {
 	    dp = lookup_dumptype(subsec_name);
 	    if (!dp) goto out;
 	    for(np = dumptype_var; np->token != CONF_UNKNOWN; np++) {
@@ -8273,7 +8273,7 @@ parm_key_info(
 	    if (val) *val = &dp->value[np->parm];
 	    if (parm) *parm = np;
 	    success = TRUE;
-	} else if (strcmp(subsec_type, "HOLDINGDISK") == 0) {
+	} else if (g_str_equal(subsec_type, "HOLDINGDISK")) {
 	    hp = lookup_holdingdisk(subsec_name);
 	    if (!hp) goto out;
 	    for(np = holding_var; np->token != CONF_UNKNOWN; np++) {
@@ -8285,7 +8285,7 @@ parm_key_info(
 	    if (val) *val = &hp->value[np->parm];
 	    if (parm) *parm = np;
 	    success = TRUE;
-	} else if (strcmp(subsec_type, "INTERFACE") == 0) {
+	} else if (g_str_equal(subsec_type, "INTERFACE")) {
 	    ip = lookup_interface(subsec_name);
 	    if (!ip) goto out;
 	    for(np = interface_var; np->token != CONF_UNKNOWN; np++) {
@@ -8298,8 +8298,8 @@ parm_key_info(
 	    if (parm) *parm = np;
 	    success = TRUE;
 	/* accept the old name here, too */
-	} else if (strcmp(subsec_type, "APPLICATION_TOOL") == 0
-		|| strcmp(subsec_type, "APPLICATION") == 0) {
+	} else if (g_str_equal(subsec_type, "APPLICATION_TOOL")
+		|| g_str_equal(subsec_type, "APPLICATION")) {
 	    ap = lookup_application(subsec_name);
 	    if (!ap) goto out;
 	    for(np = application_var; np->token != CONF_UNKNOWN; np++) {
@@ -8312,8 +8312,8 @@ parm_key_info(
 	    if (parm) *parm = np;
 	    success = TRUE;
 	/* accept the old name here, too */
-	} else if (strcmp(subsec_type, "SCRIPT_TOOL") == 0
-		|| strcmp(subsec_type, "SCRIPT") == 0) {
+	} else if (g_str_equal(subsec_type, "SCRIPT_TOOL")
+		|| g_str_equal(subsec_type, "SCRIPT")) {
 	    pp = lookup_pp_script(subsec_name);
 	    if (!pp) goto out;
 	    for(np = pp_script_var; np->token != CONF_UNKNOWN; np++) {
@@ -8325,7 +8325,7 @@ parm_key_info(
 	    if (val) *val = &pp->value[np->parm];
 	    if (parm) *parm = np;
 	    success = TRUE;
-	} else if (strcmp(subsec_type, "DEVICE") == 0) {
+	} else if (g_str_equal(subsec_type, "DEVICE")) {
 	    dc = lookup_device_config(subsec_name);
 	    if (!dc) goto out;
 	    for(np = device_config_var; np->token != CONF_UNKNOWN; np++) {
@@ -8337,7 +8337,7 @@ parm_key_info(
 	    if (val) *val = &dc->value[np->parm];
 	    if (parm) *parm = np;
 	    success = TRUE;
-	} else if (strcmp(subsec_type, "CHANGER") == 0) {
+	} else if (g_str_equal(subsec_type, "CHANGER")) {
 	    cc = lookup_changer_config(subsec_name);
 	    if (!cc) goto out;
 	    for(np = changer_config_var; np->token != CONF_UNKNOWN; np++) {
@@ -8360,7 +8360,7 @@ parm_key_info(
 
 	/* look up the keyword */
 	for(kt = keytable; kt->token != CONF_UNKNOWN; kt++) {
-	    if(kt->keyword && strcmp(kt->keyword, key) == 0)
+	    if(kt->keyword && g_str_equal(kt->keyword, key))
 		break;
 	}
 	if(kt->token == CONF_UNKNOWN) goto out;
@@ -8439,9 +8439,9 @@ string_to_boolean(
     }
 
     /* 0 and 1 are not in the table, as they are parsed as ints */
-    if (0 == strcmp(str, "0"))
+    if (g_str_equal(str, "0"))
 	return 0;
-    if (0 == strcmp(str, "1"))
+    if (g_str_equal(str, "1"))
 	return 1;
 
     for (table_entry = bool_keytable; table_entry->keyword != NULL;
@@ -8596,9 +8596,9 @@ data_path_t
 data_path_from_string(
     char *data)
 {
-    if (strcmp(data, "AMANDA") == 0)
+    if (g_str_equal(data, "AMANDA"))
 	return DATA_PATH_AMANDA;
-    if (strcmp(data, "DIRECTTCP") == 0)
+    if (g_str_equal(data, "DIRECTTCP"))
 	return DATA_PATH_DIRECTTCP;
     error(_("datapath is not AMANDA or DIRECTTCP :%s:"), data);
     /* NOTREACHED */

--- a/common-src/debug.c
+++ b/common-src/debug.c
@@ -353,10 +353,10 @@ debug_unlink_old(void)
 	    continue;
 	}
 	d_name_len = strlen(entry->d_name);
-	if(strncmp(entry->d_name, pname, pname_len) != 0
+	if(!g_str_has_prefix(entry->d_name, pname)
 	   || entry->d_name[pname_len] != '.'
 	   || d_name_len < 6
-	   || strcmp(entry->d_name + d_name_len - 6, ".debug") != 0) {
+	   || !g_str_equal(entry->d_name + d_name_len - 6, ".debug")) {
 	    continue;				/* not one of our debug files */
 	}
 	g_free(e);
@@ -633,7 +633,7 @@ debug_rename(
     g_free(s);
     s = g_strconcat(dbgdir, db_name, NULL);
 
-    if (strcmp(db_filename, s) == 0) {
+    if (g_str_equal(db_filename, s)) {
 	amfree(s);
 	return;
     }

--- a/common-src/file.c
+++ b/common-src/file.c
@@ -107,7 +107,7 @@ rmpdir(
     int rc;
     char *p, *dir;
 
-    if(strcmp(file, topdir) == 0) return 0; /* all done */
+    if(g_str_equal(file, topdir)) return 0; /* all done */
 
     rc = rmdir(file);
     if (rc != 0) switch(errno) {

--- a/common-src/glib-util.c
+++ b/common-src/glib-util.c
@@ -155,7 +155,7 @@ gboolean g_value_compare(GValue * a, GValue * b) {
         gboolean rval;
         a_str = g_strdup_value_contents(a);
         b_str = g_strdup_value_contents(b);
-        rval = (0 == strcmp(a_str, b_str));
+        rval = (g_str_equal(a_str, b_str));
         amfree(a_str);
         amfree(b_str);
         return rval;

--- a/common-src/hexencode-test.c
+++ b/common-src/hexencode-test.c
@@ -48,7 +48,7 @@ test_encode(void)
     ret = TRUE;
     for (i = 0; i < num; i++) {
         tmp = hexencode_string(test_strs[i].in);
-        if (!tmp || strcmp(test_strs[i].out, tmp)) {
+        if (!tmp || !g_str_equal(test_strs[i].out, tmp)) {
             ret = FALSE;
             tu_dbg("encode failure:\n")
             tu_dbg("input:    \"%s\"\n", test_strs[i].in);
@@ -89,7 +89,7 @@ test_decode(void)
     ret = TRUE;
     for (i = 0; i < num; i++) {
         tmp = hexdecode_string(test_strs[i].in, &err);
-        if (!tmp || strcmp(test_strs[i].out, tmp) ||
+        if (!tmp || !g_str_equal(test_strs[i].out, tmp) ||
             (!!err != test_strs[i].expect_err)) {
             ret = FALSE;
             tu_dbg("decode failure:\n")
@@ -128,7 +128,7 @@ test_roundtrip(void)
     for (i = 0; i < num; i++) {
         tmp_enc = hexencode_string(test_strs[i]);
         tmp_dec = tmp_enc? hexdecode_string(tmp_enc, &err) : NULL;
-        if (!tmp_enc || !tmp_dec || strcmp(test_strs[i], tmp_dec) || err) {
+        if (!tmp_enc || !tmp_dec || !g_str_equal(test_strs[i], tmp_dec) || err) {
             ret = FALSE;
             tu_dbg("roundtrip failure:\n")
             tu_dbg("input:      \"%s\"\n", test_strs[i]);
@@ -161,7 +161,7 @@ test_roundtrip_rand(void)
         simpleprng_fill_buffer(&state, in, size);
         tmp_enc = hexencode_string(in);
         tmp_dec = tmp_enc? hexdecode_string(tmp_enc, &err) : NULL;
-        if (!tmp_enc || !tmp_dec || strcmp(in, tmp_dec) || err) {
+        if (!tmp_enc || !tmp_dec || !g_str_equal(in, tmp_dec) || err) {
             ret = FALSE;
             tu_dbg("roundtrip failure:\n")
             tu_dbg("input:      \"%s\"\n", in);

--- a/common-src/ipc-binary-test.c
+++ b/common-src/ipc-binary-test.c
@@ -99,7 +99,7 @@ test_sync_parent(ipc_binary_proto_t *proto, int fd)
 	tu_dbg("got NULL hostname\n");
 	return 0;
     }
-    if (0 != strcmp((gchar *)msg->args[MY_PROTO_HOSTNAME].data, "localhost")) {
+    if (!g_str_equal((gchar *)msg->args[MY_PROTO_HOSTNAME].data, "localhost")) {
 	tu_dbg("got bad hostname %s\n", (gchar *)msg->args[MY_PROTO_HOSTNAME].data);
 	return 0;
     }
@@ -119,7 +119,7 @@ test_sync_parent(ipc_binary_proto_t *proto, int fd)
 	tu_dbg("got NULL hostname\n");
 	return 0;
     }
-    if (0 != strcmp((gchar *)msg->args[MY_PROTO_HOSTNAME].data, "otherhost")) {
+    if (!g_str_equal((gchar *)msg->args[MY_PROTO_HOSTNAME].data, "otherhost")) {
 	tu_dbg("got bad hostname %s\n", (gchar *)msg->args[MY_PROTO_HOSTNAME].data);
 	return 0;
     }
@@ -127,7 +127,7 @@ test_sync_parent(ipc_binary_proto_t *proto, int fd)
 	tu_dbg("got NULL disk\n");
 	return 0;
     }
-    if (0 != strcmp((gchar *)msg->args[MY_PROTO_DISK].data, "/usr")) {
+    if (!g_str_equal((gchar *)msg->args[MY_PROTO_DISK].data, "/usr")) {
 	tu_dbg("got bad disk %s\n", (gchar *)msg->args[MY_PROTO_DISK].data);
 	return 0;
     }
@@ -149,7 +149,7 @@ test_sync_parent(ipc_binary_proto_t *proto, int fd)
 	tu_dbg("got data length %d, expected 9\n", (int)msg->args[MY_PROTO_DATA].len);
 	return 0;
     }
-    if (0 != strncmp((gchar *)msg->args[MY_PROTO_DATA].data, "some-data", 9)) {
+    if (!g_str_has_prefix((gchar *)msg->args[MY_PROTO_DATA].data, "some-data")) {
 	tu_dbg("got bad data\n");
 	return 0;
     }

--- a/common-src/krb5-security.c
+++ b/common-src/krb5-security.c
@@ -1059,7 +1059,7 @@ krb5_checkuser( char *	host,
     char *	realm)
 {
 #ifdef AMANDA_PRINCIPAL
-    if(strcmp(name, AMANDA_PRINCIPAL) == 0) {
+    if(g_str_equal(name, AMANDA_PRINCIPAL)) {
 	return(NULL);
     } else {
 	return(g_strdup(_("does not match compiled in default")));
@@ -1101,7 +1101,7 @@ krb5_checkuser( char *	host,
 	 * in this case we check to see if the principal matches
 	 * the destination user mimicing the .k5login functionality.
 	 */
-	 if(strcmp(name, CLIENT_LOGIN) != 0) {
+	 if(!g_str_equal(name, CLIENT_LOGIN)) {
 		result = g_strdup_printf(_("%s does not match %s"),
 			name, CLIENT_LOGIN);
 		return result;
@@ -1154,7 +1154,7 @@ krb5_checkuser( char *	host,
 	    filehost = NULL;
 	}
 
-	if(filehost && strcmp(filehost, host) != 0) {
+	if(filehost && !g_str_equal(filehost, host)) {
 	    amfree(line);
 	    continue;
 	} else {
@@ -1174,9 +1174,9 @@ krb5_checkuser( char *	host,
 	 * anyway...
 	 */
 	auth_debug(1, _("comparing %s %s\n"), fileuser, name);
-	if(strcmp(fileuser, name) == 0) {
+	if(g_str_equal(fileuser, name)) {
 		auth_debug(1, _("found a match!\n"));
-		if(realm && filerealm && (strcmp(realm, filerealm)!=0)) {
+		if(realm && filerealm && (!g_str_equal(realm, filerealm))) {
 			amfree(line);
 			continue;
 		}

--- a/common-src/local-security.c
+++ b/common-src/local-security.c
@@ -125,7 +125,7 @@ local_connect(
     }
     myhostname[sizeof(myhostname)-1] = '\0';
 
-    if (strcmp(hostname, myhostname) != 0 &&
+    if (!g_str_equal(hostname, myhostname) &&
 	match("^localhost(\\.localdomain)?$", hostname) == 0) {
 	security_seterror(&rh->sech,
 	    _("%s: is not local"), hostname);

--- a/common-src/match-test.c
+++ b/common-src/match-test.c
@@ -243,7 +243,7 @@ test_glob_to_regex(void)
 
     for (t = tests; t->glob; t++) {
 	char *regex = glob_to_regex(t->glob);
-	if (0 != strcmp(regex, t->regex)) {
+	if (!g_str_equal(regex, t->regex)) {
 	    ok = FALSE;
 	    g_fprintf(stderr, "glob_to_regex(\"%s\") returned \"%s\"; expected \"%s\"\n",
 		    t->glob, regex, t->regex);

--- a/common-src/match.c
+++ b/common-src/match.c
@@ -580,9 +580,9 @@ static gboolean glob_is_separator_only(const char *glob, char sep) {
         case 1:
             return (*glob == sep);
         case 2:
-            return !(strcmp(glob, len2_1) && strcmp(glob, len2_2));
+            return !(!g_str_equal(glob, len2_1) && !g_str_equal(glob, len2_2));
         case 3:
-            return !strcmp(glob, len3);
+            return g_str_equal(glob, len3);
         default:
             return FALSE;
     }
@@ -771,7 +771,7 @@ match_disk(
      * backslashes into slashes in the disk, and pass these new strings as
      * arguments instead of the originals.
      */
-    gboolean windows_share = !(strncmp(disk, "\\\\", 2) || strchr(disk, '/'));
+    gboolean windows_share = !(!g_str_has_prefix(disk, "\\\\") || strchr(disk, '/'));
 
     if (windows_share) {
         glob2 = convert_winglob_to_unix(glob);
@@ -873,10 +873,10 @@ match_datestamp(
 	if (!alldigits(mydateexp))
 	    goto illegal;
 	if(match_exact == 1) {
-	    return (strcmp(datestamp, mydateexp) == 0);
+	    return (g_str_equal(datestamp, mydateexp));
 	}
 	else {
-	    return (strncmp(datestamp, mydateexp, strlen(mydateexp)) == 0);
+	    return (g_str_has_prefix(datestamp, mydateexp));
 	}
     }
 illegal:
@@ -941,10 +941,10 @@ match_level(
     else {
 	if (!alldigits(mylevelexp)) goto illegal;
 	if(match_exact == 1) {
-	    return (strcmp(level, mylevelexp) == 0);
+	    return (g_str_equal(level, mylevelexp));
 	}
 	else {
-	    return (strncmp(level, mylevelexp, strlen(mylevelexp)) == 0);
+	    return (g_str_has_prefix(level, mylevelexp));
 	}
     }
 illegal:

--- a/common-src/packet.c
+++ b/common-src/packet.c
@@ -54,7 +54,7 @@ void pkt_init_empty(
     pktype_t type)
 {
     assert(pkt != NULL);
-    assert(strcmp(pkt_type2str(type), "BOGUS") != 0);
+    assert(!g_str_equal(pkt_type2str(type), "BOGUS"));
 
     pkt->type = type;
     pkt->packet_size = 1000;
@@ -69,7 +69,7 @@ void pkt_init(pkt_t *pkt, pktype_t type, const char *fmt, ...)
     int         len;
 
     assert(pkt != NULL);
-    assert(strcmp(pkt_type2str(type), "BOGUS") != 0);
+    assert(!g_str_equal(pkt_type2str(type), "BOGUS"));
     if(fmt == NULL)
 	fmt = "";
 
@@ -132,7 +132,7 @@ pkt_str2type(
     assert(typestr != NULL);
 
     for (i = 0; i < NPKTYPES; i++)
-	if (strcmp(typestr, pktypes[i].name) == 0)
+	if (g_str_equal(typestr, pktypes[i].name))
 	    return (pktypes[i].type);
     return ((pktype_t)-1);
 }

--- a/common-src/quoting-test.c
+++ b/common-src/quoting-test.c
@@ -91,7 +91,7 @@ test_round_trip(void)
 	unquoted = unquote_string(quoted);
 
 	/* if they're not the same, complain */
-	if (0 != strcmp(*strp, unquoted)) {
+	if (!g_str_equal(*strp, unquoted)) {
 	    char *safe_orig = safestr(*strp);
 	    char *safe_quoted = safestr(quoted);
 	    char *safe_unquoted = safestr(unquoted);
@@ -130,7 +130,7 @@ compare_strv(
     const char **a = exp;
     char **b = got;
     while (*a && *b) {
-	if (0 != strcmp(*a, *b))
+	if (!g_str_equal(*a, *b))
 	    break;
 	a++; b++;
     }
@@ -309,7 +309,7 @@ test_unquote_string(void)
 	char *unquoted = unquote_string(quoted);
 
 	/* if they're not the same, complain */
-	if (0 != strcmp(expected, unquoted)) {
+	if (!g_str_equal(expected, unquoted)) {
 	    char *safe_quoted = safestr(quoted);
 	    char *safe_unquoted = safestr(unquoted);
 	    char *safe_expected = safestr(expected);
@@ -366,7 +366,7 @@ test_strquotedstr_skipping(void)
 		    success = FALSE;
 		    goto next;
 		}
-		if (0 != strcmp(tok, expected)) {
+		if (!g_str_equal(tok, expected)) {
 		    char *safe = safestr(tok);
 
 		    g_fprintf(stderr, "while parsing '%s', call %d to strquotedstr returned '%s' "
@@ -458,7 +458,7 @@ test_strquotedstr_edge_valid(void)
 	    g_fprintf(stderr, "while parsing valid '%s', strquotedstr returned NULL\n",
 		      *iter);
 	    success = FALSE;
-	} else if (0 != strcmp(tok, expected)) {
+	} else if (!g_str_equal(tok, expected)) {
 	    g_fprintf(stderr, "while parsing valid '%s', strquotedstr returned '%s' while "
 		      "'%s' was expected\n",
 		      *iter, tok, expected);

--- a/common-src/tapelist.c
+++ b/common-src/tapelist.c
@@ -93,7 +93,7 @@ append_to_tapelist(
 
     /* see if we have this tape already, and if so just add to its file list */
     for(cur_tape = tapelist; cur_tape; cur_tape = cur_tape->next) {
-	if(strcmp(label, cur_tape->label) == 0) {
+	if(g_str_equal(label, cur_tape->label)) {
 	    int d_idx = 0;
 	    off_t *newfiles;
 	    int   *newpartnum;

--- a/common-src/testutils.c
+++ b/common-src/testutils.c
@@ -174,17 +174,17 @@ testutils_run_tests(
 
     /* first_parse the command line */
     while (argc > 1) {
-	if (strcmp(argv[1], "-d") == 0) {
+	if (g_str_equal(argv[1], "-d")) {
 	    tu_debugging_enabled = TRUE;
-	} else if (strcmp(argv[1], "-t") == 0) {
+	} else if (g_str_equal(argv[1], "-t")) {
 	    ignore_timeouts = TRUE;
-	} else if (strcmp(argv[1], "-n") == 0) {
+	} else if (g_str_equal(argv[1], "-n")) {
 	    skip_fork = TRUE;
 	    only_one = TRUE;
-	} else if (strcmp(argv[1], "-l") == 0) {
+	} else if (g_str_equal(argv[1], "-l")) {
 	    loop_forever = TRUE;
 	    only_one = TRUE;
-	} else if (strcmp(argv[1], "-c") == 0) {
+	} else if (g_str_equal(argv[1], "-c")) {
             char *p;
             argv++, argc--;
             occurrences = g_ascii_strtoull(argv[1], &p, 10);
@@ -201,14 +201,14 @@ testutils_run_tests(
                 g_fprintf(stderr, "Sorry, I will not run tests 0 times\n");
                 exit(1);
             }
-	} else if (strcmp(argv[1], "-h") == 0) {
+	} else if (g_str_equal(argv[1], "-h")) {
 	    usage(tests);
 	    return 1;
 	} else {
 	    int found = 0;
 
 	    for (t = tests; t->fn; t++) {
-		if (strcmp(argv[1], t->name) == 0) {
+		if (g_str_equal(argv[1], t->name)) {
 		    found = 1;
 		    t->selected = 1;
 		    break;

--- a/common-src/timestamp.c
+++ b/common-src/timestamp.c
@@ -122,7 +122,7 @@ time_t get_time_from_timestamp(char *timestamp)
 time_state_t get_timestamp_state(char * timestamp) {
     if (timestamp == NULL || *timestamp == '\0') {
         return TIME_STATE_REPLACE;
-    } else if (strcmp(timestamp, "X") == 0) {
+    } else if (g_str_equal(timestamp, "X")) {
         return TIME_STATE_UNDEF;
     } else {
         return TIME_STATE_SET;

--- a/device-src/activate-devpay.c
+++ b/device-src/activate-devpay.c
@@ -133,10 +133,10 @@ static void parser_got_text(GMarkupParseContext * context,
         return;
     } else if (g_strrstr(current_tag, "Code")) {
         /* Is it a code we know? */
-        if (strncmp(text, "ExpiredActivationKey", text_len) == 0) {
+        if (g_str_has_prefix(text, "ExpiredActivationKey")) {
             g_set_error(error, G_MARKUP_ERROR, -1,
                         "Activation key has expired; get a new one.");
-        } else if (strncmp(text, "InvalidActivationKey", text_len) == 0) {
+        } else if (g_str_has_prefix(text, "InvalidActivationKey")) {
             g_set_error(error, G_MARKUP_ERROR, -1,
                         "Activation key is not valid; double-check.");
         } else {

--- a/device-src/device.c
+++ b/device-src/device.c
@@ -599,7 +599,7 @@ device_set_error(Device *self, char *errmsg, DeviceStatusFlags new_flags)
 
     device_name = self->device_name? self->device_name : "(unknown device)";
 
-    if (errmsg && (!selfp->errmsg || strcmp(errmsg, selfp->errmsg) != 0))
+    if (errmsg && (!selfp->errmsg || !g_str_equal(errmsg, selfp->errmsg)))
 	g_debug("Device %s error = '%s'", device_name, errmsg);
 
     amfree(selfp->errmsg);

--- a/device-src/dvdrw-device.c
+++ b/device-src/dvdrw-device.c
@@ -233,7 +233,7 @@ dvdrw_device_factory(char *device_name, char *device_type, char *device_node)
 {
     Device *device;
 
-    g_assert(0 == strncmp(device_type, "dvdrw", strlen("dvdrw")));
+    g_assert(g_str_has_prefix(device_type, "dvdrw"));
 
     device = DEVICE(g_object_new(TYPE_DVDRW_DEVICE, NULL));
     device_open_device(device, device_name, device_type, device_node);

--- a/device-src/ndmp-device.c
+++ b/device-src/ndmp-device.c
@@ -1819,7 +1819,7 @@ ndmp_device_factory(
 {
     Device *rval;
     NdmpDevice * ndmp_rval;
-    g_assert(0 == strcmp(device_type, NDMP_DEVICE_NAME));
+    g_assert(g_str_equal(device_type, NDMP_DEVICE_NAME));
     rval = DEVICE(g_object_new(TYPE_NDMP_DEVICE, NULL));
     ndmp_rval = (NdmpDevice *)rval;
 

--- a/device-src/null-device.c
+++ b/device-src/null-device.c
@@ -197,7 +197,7 @@ null_device_base_init (NullDeviceClass * c)
 
 static Device* null_device_factory(char * device_name, char * device_type, char * device_node) {
     Device * device;
-    g_assert(0 == strcmp(device_type, "null"));
+    g_assert(g_str_equal(device_type, "null"));
     device = DEVICE(g_object_new(TYPE_NULL_DEVICE, NULL));
     device_open_device(device, device_name, device_type, device_node);
     return device;

--- a/device-src/rait-device.c
+++ b/device-src/rait-device.c
@@ -860,9 +860,9 @@ static void device_open_do_op(gpointer data,
                               gpointer user_data G_GNUC_UNUSED) {
     OpenDeviceOp * op = data;
 
-    if (strcmp(op->device_name, "ERROR") == 0 ||
-        strcmp(op->device_name, "MISSING") == 0 ||
-        strcmp(op->device_name, "DEGRADED") == 0) {
+    if (g_str_equal(op->device_name, "ERROR") ||
+        g_str_equal(op->device_name, "MISSING") ||
+        g_str_equal(op->device_name, "DEGRADED")) {
         g_warning("RAIT device %s contains a missing element, attempting "
                   "degraded mode.\n", op->rait_name);
         op->result = NULL;
@@ -984,7 +984,7 @@ static void
 rait_device_open_device (Device * dself, char * device_name,
 	    char * device_type G_GNUC_UNUSED, char * device_node) {
 
-    if (0 != strcmp(device_node, DEFER_CHILDREN_SENTINEL)) {
+    if (!g_str_equal(device_node, DEFER_CHILDREN_SENTINEL)) {
 	if (!open_child_devices(dself, device_name, device_node))
 	    return;
 
@@ -1264,8 +1264,8 @@ rait_device_start (Device * dself, DeviceAccessMode mode, char * label,
         } else {
 	    if (child->volume_label != NULL && child->volume_time != NULL) {
                 if (label_from_device) {
-                    if (strcmp(child->volume_label, dself->volume_label) != 0 ||
-                        strcmp(child->volume_time, dself->volume_time) != 0) {
+                    if (!g_str_equal(child->volume_label, dself->volume_label) ||
+                        !g_str_equal(child->volume_time, dself->volume_time)) {
                         /* Mismatch! (Two devices provided different labels) */
                         char * this_message =
                             g_strdup_printf("%s: Label (%s/%s) is different "
@@ -2586,7 +2586,7 @@ rait_device_finish (Device * self) {
 static Device *
 rait_device_factory (char * device_name, char * device_type, char * device_node) {
     Device * rval;
-    g_assert(0 == strcmp(device_type, "rait"));
+    g_assert(g_str_equal(device_type, "rait"));
     rval = DEVICE(g_object_new(TYPE_RAIT_DEVICE, NULL));
     device_open_device(rval, device_name, device_type, device_node);
     return rval;

--- a/device-src/s3-device.c
+++ b/device-src/s3-device.c
@@ -578,7 +578,7 @@ static int key_to_file(guint prefix_len, const char * key) {
 
     key += prefix_len;
 
-    if (strncmp(key, SPECIAL_INFIX, strlen(SPECIAL_INFIX)) == 0) {
+    if (g_str_has_prefix(key, SPECIAL_INFIX)) {
         return 0;
     }
 
@@ -1362,7 +1362,7 @@ s3_device_factory(char * device_name, char * device_type, char * device_node)
 {
     Device *rval;
     S3Device * s3_rval;
-    g_assert(0 == strcmp(device_type, S3_DEVICE_NAME));
+    g_assert(g_str_equal(device_type, S3_DEVICE_NAME));
     rval = DEVICE(g_object_new(TYPE_S3_DEVICE, NULL));
     s3_rval = (S3Device*)rval;
 
@@ -2162,7 +2162,7 @@ s3_device_read_block (Device * pself, gpointer data, int *size_req) {
 	    s3t = &self->s3t[thread];
 	    if (!s3t->idle &&
 		s3t->done &&
-		strcmp(key, (char *)s3t->filename) == 0) {
+		g_str_equal(key, (char *)s3t->filename)) {
 		if (s3t->eof) {
 		    /* return eof */
 		    g_free(key);

--- a/device-src/tape-device.c
+++ b/device-src/tape-device.c
@@ -1978,7 +1978,7 @@ tape_device_eod (TapeDevice * self) {
 static Device *
 tape_device_factory (char * device_name, char * device_type, char * device_node) {
     Device * rval;
-    g_assert(0 == strcmp(device_type, "tape"));
+    g_assert(g_str_equal(device_type, "tape"));
     rval = DEVICE(g_object_new(TYPE_TAPE_DEVICE, NULL));
     device_open_device(rval, device_name, device_type, device_node);
     return rval;

--- a/device-src/vfs-device.c
+++ b/device-src/vfs-device.c
@@ -408,7 +408,7 @@ static void vfs_device_finalize(GObject * obj_self) {
 
 static Device * vfs_device_factory(char * device_name, char * device_type, char * device_node) {
     Device * rval;
-    g_assert(0 == strcmp(device_type, "file"));
+    g_assert(g_str_equal(device_type, "file"));
     rval = DEVICE(g_object_new(TYPE_VFS_DEVICE, NULL));
     device_open_device(rval, device_name, device_type, device_node);
     return rval;
@@ -592,7 +592,7 @@ static gboolean delete_vfs_files_functor(const char * filename,
     d_self = DEVICE(self);
 
     /* Skip the volume lock. */
-    if (strcmp(filename, VOLUME_LOCKFILE_NAME) == 0)
+    if (g_str_equal(filename, VOLUME_LOCKFILE_NAME))
         return TRUE;
 
     path_name = g_strjoin(NULL, self->dir_name, "/", filename, NULL);
@@ -620,7 +620,7 @@ static gboolean check_dir_empty_functor(const char * filename,
     VfsDevice * self = VFS_DEVICE(user_data);
     char * path_name;
 
-    if (strcmp(filename, VOLUME_LOCKFILE_NAME) == 0)
+    if (g_str_equal(filename, VOLUME_LOCKFILE_NAME))
         return TRUE;
 
     path_name = g_strjoin(NULL, self->dir_name, "/", filename, NULL);

--- a/ndmp-src/ndma_comm_dispatch.c
+++ b/ndmp-src/ndma_comm_dispatch.c
@@ -1956,7 +1956,7 @@ data_ok_bu_type (struct ndm_session *sess,
 	for (i = 0; i < ci->butype_info.butype_info_len; i++) {
 		bu = &ci->butype_info.butype_info_val[i];
 
-		if (strcmp (bu_type, bu->butype_name) == 0) {
+		if (g_str_equal(bu_type, bu->butype_name)) {
 			return 0;
 		}
 	}

--- a/ndmp-src/ndma_cops_backreco.c
+++ b/ndmp-src/ndma_cops_backreco.c
@@ -350,7 +350,7 @@ ndmca_monitor_backup_tape_tcp (struct ndm_session *sess)
 			  ca->data_state.bytes_processed/1024LL,
 			  estb ? estb : "");
 
-		if (strcmp(pname, "amndmjob") == 0) {
+		if (g_str_equal(pname, "amndmjob")) {
 			ndmlogf (ixlog, "DATA SIZE", 0, "%lldKB",
 				 ca->data_state.bytes_processed/1024LL);
 		}

--- a/ndmp-src/ndma_cops_query.c
+++ b/ndmp-src/ndma_cops_query.c
@@ -719,7 +719,7 @@ ndmca_opq_show_device_info (struct ndm_session *sess,
 			dc = &info[i].caplist.caplist_val[j];
 
 			ndmalogqr (sess, "    device     %s", dc->device);
-			if (!strcmp(what, "tape")) {
+			if (g_str_equal(what, "tape")) {
 #ifndef NDMOS_OPTION_NO_NDMP3
 			    if (sess->plumb.tape->protocol_version == 3) {
 				attr = dc->v3attr.value;

--- a/ndmp-src/ndma_ctrl_media.c
+++ b/ndmp-src/ndma_ctrl_media.c
@@ -392,10 +392,10 @@ ndmca_media_read_label (struct ndm_session *sess, char labbuf[])
 
 	if (rc == 0) {
 		p = tape_read_buf;
-		if (strncmp (p, "##ndmjob -m ", 12) == 0) {
+		if (g_str_has_prefix(p, "##ndmjob -m ")) {
 			p += 12;
 			rc = 'm';
-		} else if (strncmp (p, "##ndmjob -V ", 12) == 0) {
+		} else if (g_str_has_prefix(p, "##ndmjob -V ")) {
 			p += 12;
 			rc = 'V';
 		} else {
@@ -458,7 +458,7 @@ ndmca_media_check_label (struct ndm_session *sess, int type, char labbuf[])
 		return -1;
 	}
 
-	if (rc != type || strcmp (labbuf, mylabbuf) != 0) {
+	if (rc != type || !g_str_equal(labbuf, mylabbuf)) {
 		ndmalogf (sess, 0, 0,
 			"Label mismatch, expected -%c'%s', got -%c'%s'",
 			type, labbuf, rc, mylabbuf);

--- a/ndmp-src/ndma_data.c
+++ b/ndmp-src/ndma_data.c
@@ -865,7 +865,7 @@ ndmda_find_env (struct ndm_session *sess, char *name)
 
 	for (i = 0; i < da->env_tab.n_env; i++) {
 		pv = &da->env_tab.env[i];
-		if (strcmp (pv->name, name) == 0)
+		if (g_str_equal(pv->name, name))
 			return pv;
 	}
 

--- a/ndmp-src/ndmjob_args.c
+++ b/ndmp-src/ndmjob_args.c
@@ -154,12 +154,12 @@ process_args (int argc, char *argv[])
 
 	progname = argv[0];
 
-	if (argc == 2 && strcmp (argv[1], "-help") == 0) {
+	if (argc == 2 && g_str_equal(argv[1], "-help")) {
 		help();
 		exit(0);
 	}
 
-	if (argc == 2 && strcmp (argv[1], "-v") == 0) {
+	if (argc == 2 && g_str_equal(argv[1], "-v")) {
 		ndmjob_version_info ();
 		exit(0);
 	}
@@ -176,7 +176,7 @@ process_args (int argc, char *argv[])
 	for (pp = help_text; *pp; pp++) {
 		p = *pp;
 
-		if (strncmp (p, "  -", 3) != 0)
+		if (!g_str_has_prefix(p, "  -"))
 			continue;
 		if (p[3] == 'o')
 			continue;	/* don't include o: repeatedly */
@@ -616,50 +616,50 @@ handle_long_option (char *str)
 				break;
 			}
 		}
-	} else if (strcmp (name, "swap-connect") == 0) {
+	} else if (g_str_equal(name, "swap-connect")) {
 		/* value part ignored */
 		o_swap_connect++;
-	} else if (strcmp (name, "time-limit") == 0) {
+	} else if (g_str_equal(name, "time-limit")) {
 		if (!value) {
 			o_time_limit = 5*60;
 		} else {
 			o_time_limit = atoi(value);
 		}
-	} else if (strcmp (name, "use-eject") == 0) {
+	} else if (g_str_equal(name, "use-eject")) {
 		if (!value) {
 			o_use_eject = 1;
 		} else {
 			o_use_eject = atoi(value);
 		}
-	} else if (strcmp (name, "tape-addr") == 0 && value) {
+	} else if (g_str_equal(name, "tape-addr") && value) {
 		o_tape_addr = atoi(value);
-	} else if (strcmp (name, "from-addr") == 0 && value) {
+	} else if (g_str_equal(name, "from-addr") && value) {
 		o_from_addr = atoi(value);
-	} else if (strcmp (name, "to-addr") == 0 && value) {
+	} else if (g_str_equal(name, "to-addr") && value) {
 		o_to_addr = atoi(value);
-	} else if (strcmp (name, "tape-timeout") == 0 && value) {
+	} else if (g_str_equal(name, "tape-timeout") && value) {
 		o_tape_timeout = atoi(value);
-	} else if (strcmp (name, "robot-timeout") == 0 && value) {
+	} else if (g_str_equal(name, "robot-timeout") && value) {
 		o_robot_timeout = atoi(value);
-	} else if (strcmp (name, "tape-scsi") == 0 && value) {
+	} else if (g_str_equal(name, "tape-scsi") && value) {
 		if (ndmscsi_target_from_str (&o_tape_scsi, value)) {
 			error_byebye ("bad -otape-scsi argument");
 		}
-	} else if (strcmp (name, "rules") == 0 && value) {
+	} else if (g_str_equal(name, "rules") && value) {
 		if (!value)
 			error_byebye ("missing RULES in -o rules");
 		o_rules = value;
-	} else if (strcmp (name, "load-files") == 0 && value) {
+	} else if (g_str_equal(name, "load-files") && value) {
 		o_load_files_file = value;
 #endif /* !NDMOS_OPTION_NO_CONTROL_AGENT */
-	} else if (strcmp (name, "no-time-stamps") == 0) {
+	} else if (g_str_equal(name, "no-time-stamps")) {
 		/* value part ignored */
 		o_no_time_stamps++;
-	} else if (strcmp (name, "config-file") == 0 && value) {
+	} else if (g_str_equal(name, "config-file") && value) {
 		o_config_file = value;
-	} else if (strcmp (name, "tape-tcp") == 0 && value) {
+	} else if (g_str_equal(name, "tape-tcp") && value) {
 		o_tape_tcp = value;
-	} else if (strcmp (name, "tape-limit") == 0) {
+	} else if (g_str_equal(name, "tape-limit")) {
 		if (!value) {
 			error_byebye ("tape-limit argument is required");
 		} else {
@@ -830,7 +830,7 @@ dump_settings (void)
 
 #ifndef NDMOS_OPTION_NO_CONTROL_AGENT
 	if (I_index_file) {
-		if (strcmp (I_index_file, "-") == 0) {
+		if (g_str_equal(I_index_file, "-")) {
 			printf ("Index to log, enable FILEHIST\n");
 		} else {
 			printf ("Index to file %s, enable FILEHIST\n",
@@ -880,7 +880,7 @@ copy_args_expanding_macros (int argc, char *argv[], char *av[], int max_ac)
 	for (i = 0; i < argc; i++) {
 		arg = argv[i];
 
-		if (strncmp (arg, "--", 2) != 0 || arg[2] == 0) {
+		if (!g_str_has_prefix(arg, "--") || arg[2] == 0) {
 			av[ac++] = arg;
 			continue;
 		}
@@ -923,7 +923,7 @@ lookup_and_snarf (char *av[], char *name)
 
 	while (ndmstz_getstanza (fp, buf, sizeof buf) >= 0) {
 		if (buf[0] == '-' && buf[1] == '-'
-		 && strcmp (buf+2, name) == 0) {
+		 && g_str_equal(buf + 2, name)) {
 			found = 1;
 			break;
 		}

--- a/ndmp-src/ndmjob_job.c
+++ b/ndmp-src/ndmjob_job.c
@@ -420,7 +420,7 @@ jndex_open (void)
 		/* no return */
 	}
 
-	if (strcmp (buf, "##ndmjob -I\n") != 0) {
+	if (!g_str_equal(buf, "##ndmjob -I\n")) {
 		fclose (fp);
 		error_byebye ("Bad 1st line in -J%s", J_index_file);
 		/* no return */
@@ -432,7 +432,7 @@ jndex_open (void)
 		/* no return */
 	}
 
-	if (strcmp (buf, "##ndmjob -J\n") != 0) {
+	if (!g_str_equal(buf, "##ndmjob -J\n")) {
 		fclose (fp);
 		error_byebye ("Bad 2nd line in -J%s", J_index_file);
 		/* no return */
@@ -495,7 +495,7 @@ jndex_merge_media (void)
 			if (! me->valid_label)
 				continue;	/* can't match it up */
 
-			if (strcmp (jme->label, me->label) != 0)
+			if (!g_str_equal(jme->label, me->label))
 				continue;
 
 			if (!jme->valid_slot &&  me->valid_slot) {

--- a/ndmp-src/ndmjob_main_util.c
+++ b/ndmp-src/ndmjob_main_util.c
@@ -40,7 +40,7 @@
 int
 start_index_file (void)
 {
-	if (I_index_file && strcmp (I_index_file, "-") != 0) {
+	if (I_index_file && !g_str_equal(I_index_file, "-")) {
 		FILE *		ifp;
 
 		if (atoi(I_index_file) != 0) {
@@ -65,7 +65,7 @@ start_index_file (void)
 int
 sort_index_file (void)
 {
-	if (I_index_file && strcmp (I_index_file, "-") != 0 &&
+	if (I_index_file && !g_str_equal(I_index_file, "-") &&
 	    atoi(I_index_file) == 0) {
 		char		cmd[512];
 

--- a/ndmp-src/ndmjr_none.h
+++ b/ndmp-src/ndmjr_none.h
@@ -37,7 +37,7 @@
 #ifndef NDMOS_OPTION_NO_CONTROL_AGENT
 
 #define NDMJR_NONE_RECOGNIZE(RULES) \
-	(strcmp (RULES, "none") == 0)
+	(g_str_equal(RULES, "none"))
 
 #define NDMJR_NONE_HELP_LINE_NAME \
 	"none"

--- a/ndmp-src/ndml_agent.c
+++ b/ndmp-src/ndml_agent.c
@@ -172,7 +172,7 @@ ndmagent_from_str (struct ndmagent *agent, char *str)
 		}
 	}
 
-	if (strcmp (agent->host, ".") == 0) {
+	if (g_str_equal(agent->host, ".")) {
 		agent->conn_type = NDMCONN_TYPE_RESIDENT;
 		strcpy (agent->host, "(resident)");
 	} else {

--- a/ndmp-src/ndml_bstf.c
+++ b/ndmp-src/ndml_bstf.c
@@ -406,7 +406,7 @@ main (int ac, char *av[])
 	int		total_n_error = 0;
 
 	i = 1;
-	if (i < ac && strcmp (av[i], "-q") == 0) {
+	if (i < ac && g_str_equal(av[i], "-q")) {
 		i++;
 		verbose = 0;
 	}

--- a/ndmp-src/ndml_config.c
+++ b/ndmp-src/ndml_config.c
@@ -102,22 +102,22 @@ ndmcfg_loadfp (FILE *fp, ndmp9_config_info *config_info)
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "butype") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "butype") && cb->sc == 2) {
 			cfg_butype (cb);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "fs") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "fs") && cb->sc == 2) {
 			cfg_fs (cb);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "tape") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "tape") && cb->sc == 2) {
 			cfg_tape (cb);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "scsi") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "scsi") && cb->sc == 2) {
 			cfg_scsi (cb);
 			continue;
 		}
@@ -181,25 +181,25 @@ cfg_butype (struct cfg_cb *cb)
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "v2attr") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "v2attr") && cb->sc == 2) {
 			ent->v2attr.valid = NDMP9_VALIDITY_VALID;
 			ent->v2attr.value = strtol (cb->sv[1], 0, 0);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "v3attr") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "v3attr") && cb->sc == 2) {
 			ent->v3attr.valid = NDMP9_VALIDITY_VALID;
 			ent->v3attr.value = strtol (cb->sv[1], 0, 0);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "v4attr") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "v4attr") && cb->sc == 2) {
 			ent->v4attr.valid = NDMP9_VALIDITY_VALID;
 			ent->v4attr.value = strtol (cb->sv[1], 0, 0);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "default_env") == 0 && cb->sc == 3) {
+		if (g_str_equal(cb->sv[0], "default_env") && cb->sc == 3) {
 			cfg_add_env (cb, &ent->default_env.default_env_len,
 				&ent->default_env.default_env_val,
 				cb->sv[1], cb->sv[2]);
@@ -265,23 +265,23 @@ cfg_fs (struct cfg_cb *cb)
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "fs_type") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "fs_type") && cb->sc == 2) {
 			ent->fs_type = NDMOS_API_STRDUP (cb->sv[1]);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "fs_physical_device") == 0
+		if (g_str_equal(cb->sv[0], "fs_physical_device")
 		 && cb->sc == 2) {
 			ent->fs_physical_device = NDMOS_API_STRDUP (cb->sv[1]);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "fs_status") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "fs_status") && cb->sc == 2) {
 			ent->fs_status = NDMOS_API_STRDUP (cb->sv[1]);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "fs_env") == 0 && cb->sc == 3) {
+		if (g_str_equal(cb->sv[0], "fs_env") && cb->sc == 3) {
 			cfg_add_env (cb, &ent->fs_env.fs_env_len,
 				&ent->fs_env.fs_env_val,
 				cb->sv[1], cb->sv[2]);
@@ -335,7 +335,7 @@ cfg_device (struct cfg_cb *cb, u_int *n_device, ndmp9_device_info **pp)
 		n_ent = 0;
 
 	for (i = 0; i < n_ent; i++) {
-		if (strcmp(ent[i].model, (*pp)[i].model) == 0) {
+		if (g_str_equal(ent[i].model, (*pp)[i].model)) {
 			ent += i;
 			goto got_model;
 		}
@@ -390,24 +390,24 @@ cfg_device (struct cfg_cb *cb, u_int *n_device, ndmp9_device_info **pp)
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "device") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "device") && cb->sc == 2) {
 			dcap->device = NDMOS_API_STRDUP (cb->sv[1]);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "v3attr") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "v3attr") && cb->sc == 2) {
 			dcap->v3attr.valid = NDMP9_VALIDITY_VALID;
 			dcap->v3attr.value = strtol (cb->sv[1], 0, 0);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "v4attr") == 0 && cb->sc == 2) {
+		if (g_str_equal(cb->sv[0], "v4attr") && cb->sc == 2) {
 			dcap->v4attr.valid = NDMP9_VALIDITY_VALID;
 			dcap->v4attr.value = strtol (cb->sv[1], 0, 0);
 			continue;
 		}
 
-		if (strcmp (cb->sv[0], "capability") == 0 && cb->sc == 3) {
+		if (g_str_equal(cb->sv[0], "capability") && cb->sc == 3) {
 			cfg_add_env (cb, &dcap->capability.capability_len,
 				&dcap->capability.capability_val,
 				cb->sv[1], cb->sv[2]);

--- a/ndmp-src/ndml_stzf.c
+++ b/ndmp-src/ndml_stzf.c
@@ -195,7 +195,7 @@ main (int ac, char *av[])
 			rewind (fp);
 			found = 0;
 			while (ndmstz_getstanza (fp, buf, sizeof buf) >= 0) {
-				if (strcmp (av[i], buf) == 0) {
+				if (g_str_equal(av[i], buf)) {
 					found = 1;
 					break;
 				}

--- a/ndmp-src/ndmos_common.c
+++ b/ndmp-src/ndmos_common.c
@@ -128,10 +128,10 @@ ndmos_sync_config_info (struct ndm_session *sess)
 int
 ndmos_ok_name_password (struct ndm_session *sess, char *name, char *pass)
 {
-	if (strcmp (name, "ndmp") != 0)
+	if (!g_str_equal(name, "ndmp"))
 		return 0;
 
-	if (strcmp (pass, "ndmp") != 0)
+	if (!g_str_equal(pass, "ndmp"))
 		return 0;
 
 	return 1;	/* OK */
@@ -160,7 +160,7 @@ int
 ndmos_ok_name_md5_digest (struct ndm_session *sess,
   char *name, char digest[16])
 {
-	if (strcmp (name, "ndmp") != 0)
+	if (!g_str_equal(name, "ndmp"))
 		return 0;
 
 	if (!ndmmd5_ok_digest (sess->md5_challenge, "ndmp", digest))

--- a/ndmp-src/ndmp3_translate.c
+++ b/ndmp-src/ndmp3_translate.c
@@ -2334,7 +2334,7 @@ ndmp_9to3_name (
 
 	/* see comment in ndmp_3to9_name() above */
 
-	if (!strcmp(name9->original_path,".")) {
+	if (g_str_equal(name9->original_path, ".")) {
 	    // special case
 	    name3->original_path = NDMOS_API_STRDUP(name9->original_path);
 	    name3->destination_dir = NDMOS_API_STRDUP(name9->destination_path);
@@ -2343,8 +2343,8 @@ ndmp_9to3_name (
 	    olen = strlen(name9->original_path);
 	    dlen = strlen(name9->destination_path);
 	    offset = dlen - olen;
-	    if ((olen < dlen) && (!strcmp(name9->original_path,
-					  &name9->destination_path[offset]))) {
+	    if ((olen < dlen) && (g_str_equal(name9->original_path,
+					      &name9->destination_path[offset]))) {
 		/* original path part of destination path */
 		name3->original_path = NDMOS_API_STRDUP(name9->original_path);
 		*buf = 0;

--- a/ndmp-src/ndmprotocol.c
+++ b/ndmp-src/ndmprotocol.c
@@ -119,7 +119,7 @@ int
 ndmp_enum_from_str (int *valp, char *str, struct ndmp_enum_str_table *table)
 {
 	for (; table->name; table++) {
-		if (strcmp(table->name, str) == 0) {
+		if (g_str_equal(table->name, str)) {
 			*valp = table->value;
 			return 1;
 		}

--- a/ndmp-src/wraplib.c
+++ b/ndmp-src/wraplib.c
@@ -120,7 +120,7 @@ wrap_main_start_image_file (struct wrap_ccb *wccb)
 	if (!filename)
 		filename = "-";
 
-	if (strcmp (filename, "-") == 0) {
+	if (g_str_equal(filename, "-")) {
 		if (wccb->op == WRAP_CCB_OP_BACKUP) {
 			fd = 1;
 		} else {
@@ -325,7 +325,7 @@ wrap_process_args (int argc, char *argv[], struct wrap_ccb *wccb)
 			return -1;
 		}
 
-		if (strcmp (p, "@-") == 0) {
+		if (g_str_equal(p, "@-")) {
 			wccb->file[wccb->n_file].fhinfo = WRAP_INVALID_FHINFO;
 		} else {
 			wccb->file[wccb->n_file].fhinfo =
@@ -401,7 +401,7 @@ wrap_find_env (struct wrap_ccb *wccb, char *name)
 	int		i;
 
 	for (i = 0; i < wccb->n_env; i++) {
-		if (strcmp (wccb->env[i].name, name) == 0)
+		if (g_str_equal(wccb->env[i].name, name))
 			return wccb->env[i].value;
 	}
 

--- a/oldrecover-src/amrecover.c
+++ b/oldrecover-src/amrecover.c
@@ -258,11 +258,11 @@ clean_pathname(
 	s[length-1]='\0';
 
     /* change "/." to "/" */
-    if(strcmp(s,"/.")==0)
+    if(g_str_equal(s, "/."))
 	s[1]='\0';
 
     /* remove "/." at end of path */
-    if(strcmp(&(s[length-2]),"/.")==0)
+    if(g_str_equal(&(s[length - 2]), "/."))
 	s[length-2]='\0';
 }
 
@@ -312,12 +312,12 @@ guess_disk (
 		  fsent.fsname ? fsent.fsname : _("(fsname null)"));
 	if ((current_length > longest_match)
 	    && (current_length <= cwd_length)
-	    && (strncmp(fsent.mntdir, cwd, current_length) == 0))
+	    && (g_str_has_prefix(fsent.mntdir, cwd)))
 	{
 	    longest_match = current_length;
 	    g_free(*mpt_guess);
 	    *mpt_guess = g_strdup(fsent.mntdir);
-	    if(strncmp(fsent.fsname,DEV_PREFIX,(strlen(DEV_PREFIX))))
+	    if(!g_str_has_prefix(fsent.fsname, DEV_PREFIX))
 	    {
 	        g_free(fsname);
 	        fsname = g_strdup(fsent.fsname);
@@ -647,7 +647,7 @@ main(
 			   cwd, dn_guess, mpt_guess);
 		    set_disk(dn_guess, mpt_guess);
 		    set_directory(cwd);
-		    if (server_happy() && strcmp(cwd, mpt_guess) != 0)
+		    if (server_happy() && !g_str_equal(cwd, mpt_guess))
 		        g_printf(_("WARNING: not on root of selected filesystem, check man-page!\n"));
 		    amfree(dn_guess);
 		    amfree(mpt_guess);

--- a/oldrecover-src/display_commands.c
+++ b/oldrecover-src/display_commands.c
@@ -144,7 +144,7 @@ suck_dir_list_from_server(void)
     if (disk_path == NULL) {
 	g_printf(_("Directory must be set before getting listing\n"));
 	return;
-    } else if(strcmp(disk_path, "/") == 0) {
+    } else if(g_str_equal(disk_path, "/")) {
 	disk_path_slash = g_strdup(disk_path);
     } else {
 	disk_path_slash = g_strconcat(disk_path, "/", NULL);
@@ -254,7 +254,7 @@ suck_dir_list_from_server(void)
 	dir = unquote_string(qdir);
 
 	/* add a '.' if it a the entry for the current directory */
-	if((strcmp(disk_path,dir)==0) || (strcmp(disk_path_slash,dir)==0)) {
+	if((g_str_equal(disk_path, dir)) || (g_str_equal(disk_path_slash, dir))) {
 	    amfree(dir);
 	    dir = g_strdup(disk_path_slash_dot);
 	}

--- a/oldrecover-src/set_commands.c
+++ b/oldrecover-src/set_commands.c
@@ -322,7 +322,7 @@ cd_glob(
     }
 
     /* convert path (assumed in cwd) to one on disk */
-    if (strcmp(disk_path, "/") == 0)
+    if (g_str_equal(disk_path, "/"))
         path_on_disk = g_strconcat("/", regex_path, NULL);
     else {
         char *clean_disk_path = clean_regex(disk_path, 0);
@@ -360,7 +360,7 @@ cd_regex(
     }
 
     /* convert path (assumed in cwd) to one on disk */
-    if (strcmp(disk_path, "/") == 0)
+    if (g_str_equal(disk_path, "/"))
         path_on_disk = g_strconcat("/", regex, NULL);
     else {
         char *clean_disk_path = clean_regex(disk_path, 0);
@@ -442,7 +442,7 @@ set_directory(
     char *ldir = NULL;
 
     /* do nothing if "." */
-    if(strcmp(dir,".")==0) {
+    if(g_str_equal(dir, ".")) {
 	show_directory();		/* say where we are */
 	return;
 	/*NOTREACHED*/
@@ -461,13 +461,13 @@ set_directory(
     if (ldir[0] == '/')
     {
 	/* absolute path specified, must start with mount point */
-	if (strcmp(mount_point, "/") == 0)
+	if (g_str_equal(mount_point, "/"))
 	{
 	    new_dir = g_strdup(ldir);
 	}
 	else
 	{
-	    if (strncmp(mount_point, ldir, strlen(mount_point)) != 0)
+	    if (!g_str_has_prefix(mount_point, ldir))
 	    {
 		g_printf(_("Invalid directory - Can't cd outside mount point \"%s\"\n"),
 		       mount_point);
@@ -488,7 +488,7 @@ set_directory(
 	new_dir = g_strdup(disk_path);
 	dp = ldir;
 	/* strip any leading ..s */
-	while (strncmp(dp, "../", 3) == 0)
+	while (g_str_has_prefix(dp, "../"))
 	{
 	    de = strrchr(new_dir, '/');	/* always at least 1 */
 	    if (de == new_dir)
@@ -503,8 +503,8 @@ set_directory(
 		dp = dp + 3;
 	    }
 	}
-	if (strcmp(dp, "..") == 0) {
-	    if (strcmp(new_dir, "/") == 0) {
+	if (g_str_equal(dp, "..")) {
+	    if (g_str_equal(new_dir, "/")) {
 		/* at top of disk */
 		g_printf(_("Invalid directory - Can't cd outside mount point \"%s\"\n"),
 		       mount_point);
@@ -527,7 +527,7 @@ set_directory(
  	    }
 	} else {
 	    /*@ignore@*/
-	    if (strcmp(new_dir, "/") != 0) {
+	    if (!g_str_equal(new_dir, "/")) {
 		strappend(new_dir, "/");
 	    }
 	    strappend(new_dir, ldir);
@@ -567,9 +567,9 @@ show_directory(void)
 {
     if (mount_point == NULL || disk_path == NULL)
         g_printf(_("Must select disk first\n"));
-    else if (strcmp(mount_point, "/") == 0)
+    else if (g_str_equal(mount_point, "/"))
 	g_printf("%s\n", disk_path);
-    else if (strcmp(disk_path, "/") == 0)
+    else if (g_str_equal(disk_path, "/"))
 	g_printf("%s\n", mount_point);
     else
 	g_printf("%s%s\n", mount_point, disk_path);
@@ -588,10 +588,10 @@ set_tape(
     {
 	if (tapedev != uqtape) {
 	    if((strchr(tapedev+1, ':') == NULL) &&
-	       (strncmp(uqtape, "null:", 5) == 0 ||
-		strncmp(uqtape, "rait:", 5) == 0 ||
-		strncmp(uqtape, "file:", 5) == 0 ||
-		strncmp(uqtape, "tape:", 5) == 0)) {
+	       (g_str_has_prefix(uqtape, "null:") ||
+		g_str_has_prefix(uqtape, "rait:") ||
+		g_str_has_prefix(uqtape, "file:") ||
+		g_str_has_prefix(uqtape, "tape:"))) {
 		tapedev = uqtape;
 	    }
 	    else {
@@ -609,7 +609,7 @@ set_tape(
 
     if (tapedev[0])
     {
-	if (strcmp(tapedev, "default") == 0)
+	if (g_str_equal(tapedev, "default"))
 	    amfree(tape_device_name);
 	else {
 	        g_free(tape_device_name);

--- a/recover-src/amrecover.c
+++ b/recover-src/amrecover.c
@@ -285,11 +285,11 @@ clean_pathname(
 	s[length-1]='\0';
 
     /* change "/." to "/" */
-    if(strcmp(s,"/.")==0)
+    if(g_str_equal(s, "/."))
 	s[1]='\0';
 
     /* remove "/." at end of path */
-    if(strcmp(&(s[length-2]),"/.")==0)
+    if(g_str_equal(&(s[length - 2]), "/."))
 	s[length-2]='\0';
 }
 
@@ -650,7 +650,7 @@ amindexd_response(
 #endif
 
 	tok = strtok(pkt->body, " ");
-	if (tok == NULL || strcmp(tok, "ERROR") != 0)
+	if (tok == NULL || !g_str_equal(tok, "ERROR"))
 	    goto bad_nak;
 
 	tok = strtok(NULL, "\n");
@@ -692,7 +692,7 @@ bad_nak:
 	 * Error response packets have "ERROR" followed by the error message
 	 * followed by a newline.
 	 */
-	if (strcmp(tok, "ERROR") == 0) {
+	if (g_str_equal(tok, "ERROR")) {
 	    tok = strtok(NULL, "\n");
 	    if (tok == NULL) {
 	        g_free(errstr);
@@ -709,14 +709,14 @@ bad_nak:
         /*
          * Regular packets have CONNECT followed by three streams
          */
-        if (strcmp(tok, "CONNECT") == 0) {
+        if (g_str_equal(tok, "CONNECT")) {
 
 	    /*
 	     * Parse the three stream specifiers out of the packet.
 	     */
 	    for (i = 0; i < NSTREAMS; i++) {
 		tok = strtok(NULL, " ");
-		if (tok == NULL || strcmp(tok, streams[i].name) != 0) {
+		if (tok == NULL || !g_str_equal(tok, streams[i].name)) {
 		    extra = g_strdup_printf(
 			   _("CONNECT token is \"%s\": expected \"%s\""),
 			   tok ? tok : _("(null)"), streams[i].name);
@@ -736,7 +736,7 @@ bad_nak:
 	/*
 	 * OPTIONS [options string] '\n'
 	 */
-	if (strcmp(tok, "OPTIONS") == 0) {
+	if (g_str_equal(tok, "OPTIONS")) {
 	    tok = strtok(NULL, "\n");
 	    if (tok == NULL) {
 		extra = g_strdup(_("OPTIONS token is missing"));

--- a/recover-src/display_commands.c
+++ b/recover-src/display_commands.c
@@ -147,7 +147,7 @@ suck_dir_list_from_server(void)
     if (disk_path == NULL) {
 	g_printf(_("Directory must be set before getting listing\n"));
 	return;
-    } else if(strcmp(disk_path, "/") == 0) {
+    } else if(g_str_equal(disk_path, "/")) {
 	disk_path_slash = g_strdup(disk_path);
     } else {
 	disk_path_slash = g_strconcat(disk_path, "/", NULL);
@@ -261,7 +261,7 @@ suck_dir_list_from_server(void)
 	dir = unquote_string(qdir);
 
 	/* add a '.' if it a the entry for the current directory */
-	if((strcmp(disk_path,dir)==0) || (strcmp(disk_path_slash,dir)==0)) {
+	if((g_str_equal(disk_path, dir)) || (g_str_equal(disk_path_slash, dir))) {
 	    amfree(dir);
 	    dir = g_strdup(disk_path_slash_dot);
 	}

--- a/recover-src/set_commands.c
+++ b/recover-src/set_commands.c
@@ -468,7 +468,7 @@ cd_glob(
     }
 
     /* convert path (assumed in cwd) to one on disk */
-    if (strcmp(disk_path, "/") == 0)
+    if (g_str_equal(disk_path, "/"))
         path_on_disk = g_strconcat("/", regex_path, NULL);
     else {
         char *clean_disk_path = clean_regex(disk_path, 0);
@@ -526,7 +526,7 @@ cd_regex(
     }
 
     /* convert path (assumed in cwd) to one on disk */
-    if (strcmp(disk_path, "/") == 0)
+    if (g_str_equal(disk_path, "/"))
         path_on_disk = g_strconcat("/", uqregex, NULL);
     else {
         char *clean_disk_path = clean_regex(disk_path, 0);
@@ -618,7 +618,7 @@ set_directory(
     int   result;
 
     /* do nothing if "." */
-    if(strcmp(dir,".")==0) {
+    if(g_str_equal(dir, ".")) {
 	show_directory();		/* say where we are */
 	return 1;
 	/*NOTREACHED*/
@@ -637,13 +637,13 @@ set_directory(
     if (ldir[0] == '/')
     {
 	/* absolute path specified, must start with mount point */
-	if (strcmp(mount_point, "/") == 0)
+	if (g_str_equal(mount_point, "/"))
 	{
 	    new_dir = g_strdup(ldir);
 	}
 	else
 	{
-	    if (strncmp(mount_point, ldir, strlen(mount_point)) != 0)
+	    if (!g_str_has_prefix(mount_point, ldir))
 	    {
 		g_printf(_("Invalid directory - Can't cd outside mount point \"%s\"\n"),
 		       mount_point);
@@ -664,7 +664,7 @@ set_directory(
 	new_dir = g_strdup(disk_path);
 	dp = ldir;
 	/* strip any leading ..s */
-	while (strncmp(dp, "../", 3) == 0)
+	while (g_str_has_prefix(dp, "../"))
 	{
 	    de = strrchr(new_dir, '/');	/* always at least 1 */
 	    if (de == new_dir)
@@ -679,8 +679,8 @@ set_directory(
 		dp = dp + 3;
 	    }
 	}
-	if (strcmp(dp, "..") == 0) {
-	    if (strcmp(new_dir, "/") == 0) {
+	if (g_str_equal(dp, "..")) {
+	    if (g_str_equal(new_dir, "/")) {
 		/* at top of disk */
 		g_printf(_("Invalid directory - Can't cd outside mount point \"%s\"\n"),
 		       mount_point);
@@ -703,7 +703,7 @@ set_directory(
  	    }
 	} else {
 	    /*@ignore@*/
-	    if (strcmp(new_dir, "/") != 0) {
+	    if (!g_str_equal(new_dir, "/")) {
 		strappend(new_dir, "/");
 	    }
 	    strappend(new_dir, ldir);
@@ -750,9 +750,9 @@ show_directory(void)
 {
     if (mount_point == NULL || disk_path == NULL)
         g_printf(_("Must select disk first\n"));
-    else if (strcmp(mount_point, "/") == 0)
+    else if (g_str_equal(mount_point, "/"))
 	g_printf("%s\n", disk_path);
-    else if (strcmp(disk_path, "/") == 0)
+    else if (g_str_equal(disk_path, "/"))
 	g_printf("%s\n", mount_point);
     else
 	g_printf("%s%s\n", mount_point, disk_path);
@@ -798,7 +798,7 @@ set_tape(
     
     if (tapedev[0])
     {
-	if (strcmp(tapedev, "default") == 0)
+	if (g_str_equal(tapedev, "default"))
 	    tapedev = NULL;
     }
 

--- a/server-src/amadmin.c
+++ b/server-src/amadmin.c
@@ -181,7 +181,7 @@ main(
     set_config_overrides(cfg_ovr);
     config_init(CONFIG_INIT_EXPLICIT_NAME, argv[1]);
 
-    if(strcmp(argv[2],"version") == 0) {
+    if(g_str_equal(argv[2], "version")) {
 	show_version(argc, argv);
 	goto done;
     }
@@ -220,7 +220,7 @@ main(
     unitdivisor = getconf_unit_divisor();
 
     for (i = 0; i < NCMDS; i++)
-	if (strcmp(argv[2], cmdtab[i].name) == 0) {
+	if (g_str_equal(argv[2], cmdtab[i].name)) {
 	    (*cmdtab[i].fn)(argc, argv);
 	    break;
 	}
@@ -845,7 +845,7 @@ tape(
     int     skip;
     int     nb_new_tape;
 
-    if(argc > 4 && strcmp(argv[3],"--days") == 0) {
+    if(argc > 4 && g_str_equal(argv[3], "--days")) {
 	nb_days = atoi(argv[4]);
 	if(nb_days < 1) {
 	    g_printf(_("days must be an integer bigger than 0\n"));
@@ -921,7 +921,7 @@ balance(
     overdue = 0;
     max_overdue = 0;
 
-    if(argc > 4 && strcmp(argv[3],"--days") == 0) {
+    if(argc > 4 && g_str_equal(argv[3], "--days")) {
 	later = atoi(argv[4]);
 	if(later < 0) later = conf_dumpcycle;
     }
@@ -1119,7 +1119,7 @@ find(
 
     g_free(sort_order);
     sort_order = g_strdup(DEFAULT_SORT_ORDER);
-    if(argc > 4 && strcmp(argv[3],"--sort") == 0) {
+    if(argc > 4 && g_str_equal(argv[3], "--sort")) {
 	size_t i, valid_sort=1;
 
 	for(i = strlen(argv[4]); i > 0; i--) {
@@ -1442,9 +1442,9 @@ holding(
 
     if (argc < 4)
         action = HOLDING_USAGE;
-    else if (strcmp(argv[3], "list") == 0 && argc >= 4)
+    else if (g_str_equal(argv[3], "list") && argc >= 4)
         action = HOLDING_LIST;
-    else if (strcmp(argv[3], "delete") == 0 && argc > 4)
+    else if (g_str_equal(argv[3], "delete") && argc > 4)
         action = HOLDING_DELETE;
 
     switch (action) {
@@ -1771,7 +1771,7 @@ import_db(
 		get_pname(), vers_maj, vers_min, vers_patch);
     /*@end@*/
 
-    if(strcmp(org, getconf_str(CNF_ORG)) != 0) {
+    if(!g_str_equal(org, getconf_str(CNF_ORG))) {
 	g_fprintf(stderr, _("%s: WARNING: input is from different org: %s\n"),
 		get_pname(), org);
     }

--- a/server-src/amcheck.c
+++ b/server-src/amcheck.c
@@ -724,7 +724,7 @@ start_server_check(
 	char *lbl_templ;
 
 	lbl_templ = tapetype_get_lbl_templ(tp);
-	if(strcmp(lbl_templ, "") != 0) {
+	if(!g_str_equal(lbl_templ, "")) {
 	    lbl_templ = config_dir_relative(lbl_templ);
 	    if(access(lbl_templ, R_OK) == -1) {
 		g_fprintf(outf,
@@ -1825,16 +1825,16 @@ start_host(
 		}
 	    }
 	    if (dp->program &&
-	        (strcmp(dp->program,"DUMP") == 0 || 
-	         strcmp(dp->program,"GNUTAR") == 0)) {
-		if(strcmp(dp->program, "DUMP") == 0 &&
+	        (g_str_equal(dp->program, "DUMP") || 
+	         g_str_equal(dp->program, "GNUTAR"))) {
+		if(g_str_equal(dp->program, "DUMP") &&
 		   !am_has_feature(hostp->features, fe_program_dump)) {
 		    g_fprintf(outf, _("ERROR: %s:%s does not support DUMP.\n"),
 			    hostp->hostname, qname);
 		    g_fprintf(outf, _("You must upgrade amanda on the client to use DUMP "
 				    "or you can use another program.\n"));	
 		}
-		if(strcmp(dp->program, "GNUTAR") == 0 &&
+		if(g_str_equal(dp->program, "GNUTAR") &&
 		   !am_has_feature(hostp->features, fe_program_gnutar)) {
 		    g_fprintf(outf, _("ERROR: %s:%s does not support GNUTAR.\n"),
 			    hostp->hostname, qname);
@@ -2177,8 +2177,8 @@ handle_result(
 	     * We can ignore this.
 	     */
 	    if(!((hostp->features == NULL) && (pkt->type == P_NAK)
-	       && ((strcmp(t - 1, "unknown service: noop") == 0)
-		   || (strcmp(t - 1, "noop: invalid service") == 0)))) {
+	       && ((g_str_equal(t - 1, "unknown service: noop"))
+		   || (g_str_equal(t - 1, "noop: invalid service"))))) {
 		g_fprintf(outf, _("ERROR: %s%s: %s\n"),
 			(pkt->type == P_NAK) ? "NAK " : "",
 			hostp->hostname,

--- a/server-src/amcleanupdisk.c
+++ b/server-src/amcleanupdisk.c
@@ -107,7 +107,7 @@ main(
     }
 
     /* parse options */
-    if (argc >= 2 && strcmp(argv[1], "-v") == 0) {
+    if (argc >= 2 && g_str_equal(argv[1], "-v")) {
 	verbose_output = stderr;
 	cfg_opt = argv[2];
     } else {

--- a/server-src/amindexd.c
+++ b/server-src/amindexd.c
@@ -213,9 +213,9 @@ uncompress_file(
 
     filename = g_strdup(filename_gz);
     len = strlen(filename);
-    if(len > 3 && strcmp(&(filename[len-3]),".gz")==0) {
+    if(len > 3 && g_str_equal(&(filename[len - 3]), ".gz")) {
 	filename[len-3]='\0';
-    } else if(len > 2 && strcmp(&(filename[len-2]),".Z")==0) {
+    } else if(len > 2 && g_str_equal(&(filename[len - 2]), ".Z")) {
 	filename[len-2]='\0';
     }
 
@@ -417,7 +417,7 @@ process_ls_dump(
     size_t len_dir_slash;
 
     old_line[0] = '\0';
-    if (strcmp(dir, "/") == 0) {
+    if (g_str_equal(dir, "/")) {
 	dir_slash = g_strdup(dir);
     } else {
 	dir_slash = g_strconcat(dir, "/", NULL);
@@ -452,7 +452,7 @@ process_ls_dump(
 	if (line[0] != '\0') {
 	    if(strlen(line) > 0 && line[strlen(line)-1] == '\n')
 		line[strlen(line)-1] = '\0';
-	    if(strncmp(dir_slash, line, len_dir_slash) == 0) {
+	    if(g_str_has_prefix(dir_slash, line)) {
 		if(!recursive) {
 		    s = line + len_dir_slash;
 		    ch = *s++;
@@ -463,7 +463,7 @@ process_ls_dump(
 		    }
 		    s[-1] = '\0';
 		}
-		if(strcmp(line, old_line) != 0) {
+		if(!g_str_equal(line, old_line)) {
 		    add_dir_list_item(dump_item, line);
 		    strcpy(old_line, line);
 		}
@@ -846,9 +846,9 @@ build_disk_table(void)
 	find_output != NULL; 
 	find_output = find_output->next) {
 	if(strcasecmp(dump_hostname, find_output->hostname) == 0 &&
-	   strcmp(disk_name    , find_output->diskname)     == 0 &&
-	   strcmp("OK"         , find_output->status)       == 0 &&
-	   strcmp("OK"         , find_output->dump_status)  == 0) {
+	   g_str_equal(disk_name, find_output->diskname) &&
+	   g_str_equal("OK", find_output->status) &&
+	   g_str_equal("OK", find_output->dump_status)) {
 	    /*
 	     * The sort order puts holding disk entries first.  We want to
 	     * use them if at all possible, so ignore any other entries
@@ -856,14 +856,14 @@ build_disk_table(void)
 	     * (as indicated by a filenum of zero).
 	     */
 	    if(last_timestamp &&
-	       strcmp(find_output->timestamp, last_timestamp) == 0 &&
+	       g_str_equal(find_output->timestamp, last_timestamp) &&
 	       find_output->level == last_level && 
 	       last_filenum == 0) {
 		continue;
 	    }
 	    /* ignore duplicate partnum */
 	    if(last_timestamp &&
-	       strcmp(find_output->timestamp, last_timestamp) == 0 &&
+	       g_str_equal(find_output->timestamp, last_timestamp) &&
 	       find_output->level == last_level && 
 	       find_output->partnum == last_partnum) {
 		continue;
@@ -984,7 +984,7 @@ is_dir_valid_opaque(
 	return -1;
     }
 
-    if(strcmp(dir, "/") == 0) {
+    if(g_str_equal(dir, "/")) {
 	ldir = g_strdup(dir);
     } else {
 	ldir = g_strconcat(dir, "/", NULL);
@@ -1024,7 +1024,7 @@ is_dir_valid_opaque(
 		continue;
 	    if(strlen(line) > 0 && line[strlen(line)-1] == '\n')
 		line[strlen(line)-1] = '\0';
-	    if (strncmp(line, ldir, ldir_len) != 0) {
+	    if (!g_str_has_prefix(line, ldir)) {
 		continue;			/* not found yet */
 	    }
 	    amfree(filename);
@@ -1264,7 +1264,7 @@ are_dumps_compressed(void)
     /* now go through the list of disks and find which have indexes */
     for (diskp = disk_list.head; diskp != NULL; diskp = diskp->next) {
 	if ((strcasecmp(diskp->host->hostname, dump_hostname) == 0)
-		&& (strcmp(diskp->name, disk_name) == 0)) {
+		&& (g_str_equal(diskp->name, disk_name))) {
 	    break;
 	}
     }
@@ -1353,13 +1353,13 @@ main(
     argc--;
     argv++;
 
-    if(argc > 0 && strcmp(*argv, "-t") == 0) {
+    if(argc > 0 && g_str_equal(*argv, "-t")) {
 	amindexd_debug = 1;
 	argc--;
 	argv++;
     }
 
-    if(argc > 0 && strcmp(*argv, "amandad") == 0) {
+    if(argc > 0 && g_str_equal(*argv, "amandad")) {
 	from_amandad = 1;
 	argc--;
 	argv++;
@@ -1553,7 +1553,7 @@ main(
 	}
 
 	amfree(errstr);
-	if (!user_validated && strcmp(cmd, "SECURITY") == 0 && arg) {
+	if (!user_validated && g_str_equal(cmd, "SECURITY") && arg) {
 	    user_validated = amindexd_debug ||
 				check_security(
 					(sockaddr_union *)&his_addr,
@@ -1573,10 +1573,10 @@ main(
 	    break;
 	}
 
-	if (strcmp(cmd, "QUIT") == 0) {
+	if (g_str_equal(cmd, "QUIT")) {
 	    amfree(line);
 	    break;
-	} else if (strcmp(cmd, "HOST") == 0 && arg) {
+	} else if (g_str_equal(cmd, "HOST") && arg) {
 	    am_host_t *lhost;
 	    /* set host we are restoring */
 	    s[-1] = '\0';
@@ -1589,7 +1589,7 @@ main(
 		amfree(disk_name);		/* invalidate any value */
 	    }
 	    s[-1] = (char)ch;
-	} else if (strcmp(cmd, "LISTHOST") == 0) {
+	} else if (g_str_equal(cmd, "LISTHOST")) {
 	    disk_t *disk, 
                    *diskdup;
 	    int nbhost = 0,
@@ -1603,7 +1603,8 @@ main(
 		for (disk = disk_list.head; disk!=NULL; disk = disk->next) {
                     found = 0;
 		    for (diskdup = disk_list.head; diskdup!=disk; diskdup = diskdup->next) {
-		        if(strcmp(diskdup->host->hostname, disk->host->hostname) == 0) {
+		        if(g_str_equal(diskdup->host->hostname,
+                                       disk->host->hostname)) {
                           found = 1;
                           break;
 		        }
@@ -1621,7 +1622,7 @@ main(
 		}
 	    }
 	    s[-1] = (char)ch;
-	} else if (strcmp(cmd, "DISK") == 0 && arg) {
+	} else if (g_str_equal(cmd, "DISK") && arg) {
 	    s[-1] = '\0';
 	    if (is_disk_valid(arg) != -1) {
 		g_free(disk_name);
@@ -1633,7 +1634,7 @@ main(
 		}
 	    }
 	    s[-1] = (char)ch;
-	} else if (strcmp(cmd, "DLE") == 0) {
+	} else if (g_str_equal(cmd, "DLE")) {
 	    disk_t *dp;
 	    char *optionstr;
 	    char *b64disk;
@@ -1692,7 +1693,7 @@ main(
 		amfree(b64disk);
 	    }
 	    }
-	} else if (strcmp(cmd, "LISTDISK") == 0) {
+	} else if (g_str_equal(cmd, "LISTDISK")) {
 	    char *qname;
 	    disk_t *disk;
 	    int nbdisk = 0;
@@ -1709,8 +1710,8 @@ main(
 		for (disk = disk_list.head; disk!=NULL; disk = disk->next) {
 
 		    if (strcasecmp(disk->host->hostname, dump_hostname) == 0 &&
-		      ((disk->device && strcmp(disk->device, arg) == 0) ||
-		      (!disk->device && strcmp(disk->name, arg) == 0))) {
+		      ((disk->device && g_str_equal(disk->device, arg)) ||
+		      (!disk->device && g_str_equal(disk->name, arg)))) {
 			qname = quote_string(disk->name);
 			fast_lreply(201, " %s", qname);
 			amfree(qname);
@@ -1744,7 +1745,7 @@ main(
 		}
 	    }
 	    s[-1] = (char)ch;
-	} else if (strcmp(cmd, "SCNF") == 0 && arg) {
+	} else if (g_str_equal(cmd, "SCNF") && arg) {
 	    s[-1] = '\0';
 	    if (check_and_load_config(arg) != -1) {    /* try to load the new config */
 		amfree(dump_hostname);		/* invalidate any value */
@@ -1753,7 +1754,7 @@ main(
 		reply(200, _("Config set to %s."), get_config_name());
 	    } /* check_and_load_config replies with any failure messages */
 	    s[-1] = (char)ch;
-	} else if (strcmp(cmd, "FEATURES") == 0 && arg) {
+	} else if (g_str_equal(cmd, "FEATURES") && arg) {
 	    char *our_feature_string = NULL;
 	    char *their_feature_string = NULL;
 	    s[-1] = '\0';
@@ -1772,25 +1773,25 @@ main(
 	    amfree(our_feature_string);
 	    amfree(their_feature_string);
 	    s[-1] = (char)ch;
-	} else if (strcmp(cmd, "DATE") == 0 && arg) {
+	} else if (g_str_equal(cmd, "DATE") && arg) {
 	    s[-1] = '\0';
 	    g_free(target_date);
 	    target_date = g_strdup(arg);
 	    reply(200, _("Working date set to %s."), target_date);
 	    s[-1] = (char)ch;
-	} else if (strcmp(cmd, "DHST") == 0) {
+	} else if (g_str_equal(cmd, "DHST")) {
 	    (void)disk_history_list();
-	} else if (strcmp(cmd, "OISD") == 0 && arg) {
+	} else if (g_str_equal(cmd, "OISD") && arg) {
 	    if (is_dir_valid_opaque(arg) != -1) {
 		reply(200, _("\"%s\" is a valid directory"), arg);
 	    }
-	} else if (strcmp(cmd, "OLSD") == 0 && arg) {
+	} else if (g_str_equal(cmd, "OLSD") && arg) {
 	    (void)opaque_ls(arg,0);
-	} else if (strcmp(cmd, "ORLD") == 0 && arg) {
+	} else if (g_str_equal(cmd, "ORLD") && arg) {
 	    (void)opaque_ls(arg, 1);
-	} else if (strcmp(cmd, "TAPE") == 0) {
+	} else if (g_str_equal(cmd, "TAPE")) {
 	    (void)tapedev_is();
-	} else if (strcmp(cmd, "DCMP") == 0) {
+	} else if (g_str_equal(cmd, "DCMP")) {
 	    (void)are_dumps_compressed();
 	} else {
 	    *cmd_undo = cmd_undo_ch;	/* restore the command line */

--- a/server-src/amtrmidx.c
+++ b/server-src/amtrmidx.c
@@ -91,7 +91,7 @@ main(
 
     cfg_ovr = extract_commandline_config_overrides(&argc, &argv);
 
-    if (argc > 1 && strcmp(argv[1], "-t") == 0) {
+    if (argc > 1 && g_str_equal(argv[1], "-t")) {
 	amtrmidx_debug = 1;
 	argc--;
 	argv++;
@@ -166,8 +166,8 @@ main(
 
 		dp_host = sanitise_filename(dp->host->hostname);
 		dp_disk = sanitise_filename(dp->name);
-		if (strcmp(host, dp_host) == 0 &&
-		    strcmp(disk, dp_disk) == 0) {
+		if (g_str_equal(host, dp_host) &&
+		    g_str_equal(disk, dp_disk)) {
 		    matching_dp = g_slist_append(matching_dp, dp);
 		}
 		amfree(dp_host);
@@ -213,7 +213,7 @@ main(
 		 */
 		l = strlen(f->d_name) - (sizeof(".tmp")-1);
 		if ((l > (len_date + 1))
-			&& (strcmp(f->d_name + l, ".tmp")==0)) {
+			&& (g_str_equal(f->d_name + l, ".tmp"))) {
 		    struct stat sbuf;
 		    char *path, *qpath;
 

--- a/server-src/amtrmlog.c
+++ b/server-src/amtrmlog.c
@@ -84,7 +84,7 @@ main(
 
     cfg_ovr = extract_commandline_config_overrides(&argc, &argv);
 
-    if (argc > 1 && strcmp(argv[1], "-t") == 0) {
+    if (argc > 1 && g_str_equal(argv[1], "-t")) {
 	amtrmidx_debug = 1;
 	argc--;
 	argv++;
@@ -163,14 +163,14 @@ main(
 	/*NOTREACHED*/
     }
     while ((adir=readdir(dir)) != NULL) {
-	if(strncmp(adir->d_name,"log.",4)==0) {
+	if(g_str_has_prefix(adir->d_name, "log.")) {
 	    useful=0;
 	    for (name=output_find_log;*name !=NULL; name++) {
 		if((strlen(adir->d_name) >= 13 &&
 		    strlen(*name) >= 13 &&
 		    adir->d_name[12] == '.' && (*name)[12] == '.' &&
-		    strncmp(adir->d_name,*name,12)==0) ||
-		   strncmp(adir->d_name,*name,18)==0) {
+		    g_str_has_prefix(adir->d_name, *name)) ||
+		   g_str_has_prefix(adir->d_name, *name)) {
 		    useful=1;
 		    break;
 		}

--- a/server-src/chunker.c
+++ b/server-src/chunker.c
@@ -739,7 +739,7 @@ databuf_flush(
 		    /*NOTREACHED*/
 		}
 
-		if(strcmp(db->filename, arg_filename) == 0) {
+		if(g_str_equal(db->filename, arg_filename)) {
 		    /*
 		     * Same disk, so use what room is left up to the
 		     * next chunk boundary or the amount we were given,

--- a/server-src/disk_history.c
+++ b/server-src/disk_history.c
@@ -78,7 +78,7 @@ add_dump(
     if (partnum > 1) {
 	for(item = disk_hist, before = NULL; item;
 	    before = item, item = item->next) {
-	    if (!strcmp(item->date, date) &&
+	    if (g_str_equal(item->date, date) &&
 		    item->level == level && item->is_split) {
 		item->tapes = append_to_tapelist(item->tapes, tape, file,
 						 partnum, isafile);

--- a/server-src/diskfile.c
+++ b/server-src/diskfile.c
@@ -119,7 +119,7 @@ lookup_disk(
 	return (NULL);
 
     for (disk = host->disks; disk != NULL; disk = disk->hostnext) {
-	if (strcmp(disk->name, diskname) == 0)
+	if (g_str_equal(disk->name, diskname))
 	    return (disk);
     }
     return (NULL);
@@ -427,7 +427,7 @@ parse_diskline(
 	hostname = g_strdup(fp);
     } else {
 	hostname = g_strdup(host->hostname);
-	if (strcmp(host->hostname, fp) != 0) {
+	if (!g_str_equal(host->hostname, fp)) {
 	    disk_parserror(filename, line_num, _("Same host with different case: \"%s\" and \"%s\"."), host->hostname, fp);
 	    return -1;
 	}
@@ -436,8 +436,8 @@ parse_diskline(
     shost = sanitise_filename(hostname);
     for (p = hostlist; p != NULL; p = p->next) {
 	char *shostp = sanitise_filename(p->hostname);
-	if (strcmp(hostname, p->hostname) &&
-	    !strcmp(shost, shostp)) {
+	if (!g_str_equal(hostname, p->hostname) &&
+	    g_str_equal(shost, shostp)) {
 	    disk_parserror(filename, line_num, _("Two hosts are mapping to the same name: \"%s\" and \"%s\""), p->hostname, hostname);
 	    return(-1);
 	}
@@ -555,8 +555,8 @@ parse_diskline(
 	sdisk = sanitise_filename(diskname);
 	for (dp = host->disks; dp != NULL; dp = dp->hostnext) {
 	    char *sdiskp = sanitise_filename(dp->name);
-	    if (strcmp(diskname, dp->name) != 0 &&
-		 strcmp(sdisk, sdiskp) == 0) {
+	    if (!g_str_equal(diskname, dp->name) &&
+		 g_str_equal(sdisk, sdiskp)) {
 		disk_parserror(filename, line_num,
 		 _("Two disks are mapping to the same name: \"%s\" and \"%s\"; you must use different diskname"),
 		 dp->name, diskname);
@@ -787,12 +787,12 @@ parse_diskline(
     }
 
     if (disk->program && disk->application &&
-	strcmp(disk->program,"APPLICATION")) {
+	!g_str_equal(disk->program, "APPLICATION")) {
 	disk_parserror(filename, line_num,
 		       _("Both program and application set"));
     }
 
-    if (disk->program && strcmp(disk->program,"APPLICATION")==0 &&
+    if (disk->program && g_str_equal(disk->program, "APPLICATION") &&
 	!disk->application) {
 	disk_parserror(filename, line_num,
 		       _("program set to APPLICATION but no application set"));

--- a/server-src/driver.c
+++ b/server-src/driver.c
@@ -253,7 +253,7 @@ main(
 	   get_pname(), (long) getpid(), argv[0], VERSION);
 
     if(argc > 2) {
-        if(strcmp(argv[2], "nodump") == 0) {
+        if(g_str_equal(argv[2], "nodump")) {
             nodump = 1;
 	    argv++;
 	    argc--;
@@ -261,7 +261,7 @@ main(
     }
 
     if (argc > 2) {
-	if (strcmp(argv[2], "--no-taper") == 0) {
+	if (g_str_equal(argv[2], "--no-taper")) {
 	    no_taper = TRUE;
 	    argv++;
 	    argc--;
@@ -269,7 +269,7 @@ main(
     }
 
     if (argc > 2) {
-	if (strcmp(argv[2], "--from-client") == 0) {
+	if (g_str_equal(argv[2], "--from-client")) {
 	    from_client = TRUE;
 	    argv++;
 	    argc--;
@@ -1575,7 +1575,7 @@ handle_taper_result(
 	    taper = NULL;
 	    taper_started = 1;
 	    for (i=0; i < conf_taper_parallel_write; i++) {
-		if (strcmp(tapetable[i].name, result_argv[1]) == 0) {
+		if (g_str_equal(tapetable[i].name, result_argv[1])) {
 		    taper= &tapetable[i];
 		}
 	    }
@@ -1613,13 +1613,13 @@ handle_taper_result(
 		   walltime_str(curclock()), dp->host->hostname, qname);
 	    fflush(stdout);
 
-	    if (strcmp(result_argv[2], "INPUT-ERROR") == 0) {
+	    if (g_str_equal(result_argv[2], "INPUT-ERROR")) {
 		g_free(taper->input_error);
 		taper->input_error = g_strdup(result_argv[4]);
 		taper->result = FAILED;
 		amfree(qname);
 		break;
-	    } else if (strcmp(result_argv[2], "INPUT-GOOD") != 0) {
+	    } else if (!g_str_equal(result_argv[2], "INPUT-GOOD")) {
 		g_free(taper->tape_error);
 		taper->tape_error = g_strdup(_("Taper protocol error"));
 		taper->result = FAILED;
@@ -1629,14 +1629,14 @@ handle_taper_result(
 		amfree(qname);
 		break;
 	    }
-	    if (strcmp(result_argv[3], "TAPE-ERROR") == 0) {
+	    if (g_str_equal(result_argv[3], "TAPE-ERROR")) {
 		taper->state &= ~TAPER_STATE_TAPE_STARTED;
 		g_free(taper->tape_error);
 		taper->tape_error = g_strdup(result_argv[5]);
 		taper->result = FAILED;
 		amfree(qname);
 		break;
-	    } else if (strcmp(result_argv[3], "TAPE-GOOD") != 0) {
+	    } else if (!g_str_equal(result_argv[3], "TAPE-GOOD")) {
 		taper->state &= ~TAPER_STATE_TAPE_STARTED;
 		g_free(taper->tape_error);
 		taper->tape_error = g_strdup(_("Taper protocol error"));
@@ -1671,13 +1671,13 @@ handle_taper_result(
 		   walltime_str(curclock()), dp->host->hostname, qname);
 	    fflush(stdout);
 
-	    if (strcmp(result_argv[2], "INPUT-ERROR") == 0) {
+	    if (g_str_equal(result_argv[2], "INPUT-ERROR")) {
 		g_free(taper->input_error);
 		taper->input_error = g_strdup(result_argv[5]);
 		taper->result = FAILED;
 		amfree(qname);
 		break;
-	    } else if (strcmp(result_argv[2], "INPUT-GOOD") != 0) {
+	    } else if (!g_str_equal(result_argv[2], "INPUT-GOOD")) {
 		g_free(taper->tape_error);
 		taper->tape_error = g_strdup(_("Taper protocol error"));
 		taper->result = FAILED;
@@ -1687,14 +1687,14 @@ handle_taper_result(
 		amfree(qname);
 		break;
 	    }
-	    if (strcmp(result_argv[3], "TAPE-ERROR") == 0) {
+	    if (g_str_equal(result_argv[3], "TAPE-ERROR")) {
 		taper->state &= ~TAPER_STATE_TAPE_STARTED;
 		g_free(taper->tape_error);
 		taper->tape_error = g_strdup(result_argv[6]);
 		taper->result = FAILED;
 		amfree(qname);
 		break;
-	    } else if (strcmp(result_argv[3], "TAPE-GOOD") != 0) {
+	    } else if (!g_str_equal(result_argv[3], "TAPE-GOOD")) {
 		taper->state &= ~TAPER_STATE_TAPE_STARTED;
 		g_free(taper->tape_error);
 		taper->tape_error = g_strdup(_("Taper protocol error"));
@@ -1850,7 +1850,7 @@ handle_taper_result(
 
         case TAPE_ERROR: /* TAPE-ERROR <name> <err mess> */
 	    taper_started = 1;
-	    if (strcmp(result_argv[1], "SETUP") == 0) {
+	    if (g_str_equal(result_argv[1], "SETUP")) {
 		taper_nb_wait_reply = 0;
 		taper_nb_scan_volume = 0;
 	    } else {
@@ -2001,7 +2001,7 @@ file_taper_result(
     if (taper->input_error) {
 	g_printf("driver: taper failed %s %s: %s\n",
 		   dp->host->hostname, qname, taper->input_error);
-	if (strcmp(sched(dp)->datestamp, driver_timestamp) == 0) {
+	if (g_str_equal(sched(dp)->datestamp, driver_timestamp)) {
 	    if(sched(dp)->taper_attempted >= 2) {
 		log_add(L_FAIL, _("%s %s %s %d [too many taper retries after holding disk error: %s]"),
 		    dp->host->hostname, qname, sched(dp)->datestamp,
@@ -2196,7 +2196,7 @@ taper_from_name(
 
     for (taper = tapetable; taper < tapetable+conf_taper_parallel_write;
 			    taper++)
-	if (strcmp(taper->name, name) == 0) return taper;
+	if (g_str_equal(taper->name, name)) return taper;
 
     return NULL;
 }
@@ -2715,11 +2715,11 @@ read_flush(
 	skip_non_whitespace(s, ch);
 	s[-1] = '\0';
 
-	if(strcmp(command,"ENDFLUSH") == 0) {
+	if(g_str_equal(command, "ENDFLUSH")) {
 	    break;
 	}
 
-	if(strcmp(command,"FLUSH") != 0) {
+	if(!g_str_equal(command, "FLUSH")) {
 	    error(_("flush line %d: syntax error (%s != FLUSH)"), line, command);
 	    /*NOTREACHED*/
 	}
@@ -2779,9 +2779,9 @@ read_flush(
 	    continue;
 	}
 
-	if(strcmp(hostname, file.name) != 0 ||
-	   strcmp(diskname, file.disk) != 0 ||
-	   strcmp(datestamp, file.datestamp) != 0) {
+	if(!g_str_equal(hostname, file.name) ||
+	   !g_str_equal(diskname, file.disk) ||
+	   !g_str_equal(datestamp, file.datestamp)) {
 	    log_add(L_INFO, _("disk %s:%s not consistent with file %s"),
 		    hostname, diskname, destname);
 	    amfree(diskname);
@@ -2927,7 +2927,7 @@ read_schedule(
 	skip_non_whitespace(s, ch);
 	s[-1] = '\0';
 
-	if(strcmp(command,"DUMP") != 0) {
+	if(!g_str_equal(command, "DUMP")) {
 	    error(_("schedule line %d: syntax error (%s != DUMP)"), line, command);
 	    /*NOTREACHED*/
 	}
@@ -3581,7 +3581,7 @@ build_diskspace(
 	}
 
 	for(j = 0, ha = holdalloc; ha != NULL; ha = ha->next, j++ ) {
-	    if(strcmp(dirname, holdingdisk_get_diskdir(ha->hdisk))==0) {
+	    if(g_str_equal(dirname, holdingdisk_get_diskdir(ha->hdisk))) {
 		break;
 	    }
 	}

--- a/server-src/driverio.c
+++ b/server-src/driverio.c
@@ -310,7 +310,7 @@ getresult(
     if(*result_argc < 1) return BOGUS;
 
     for(t = (cmd_t)(BOGUS+1); t < LAST_TOK; t++)
-	if(strcmp((*result_argv)[0], cmdstr[t]) == 0) return t;
+	if(g_str_equal((*result_argv)[0], cmdstr[t])) return t;
 
     return BOGUS;
 }
@@ -626,7 +626,7 @@ dumper_cmd(
 	    }
 
 	    g_assert(dp->program);
-	    if (0 == strcmp(dp->program, "APPLICATION")) {
+	    if (g_str_equal(dp->program, "APPLICATION")) {
 		g_assert(application != NULL);
 		plugin = application_get_plugin(application);
 	    } else {

--- a/server-src/dumper.c
+++ b/server-src/dumper.c
@@ -477,7 +477,7 @@ main(
 	    g_free(device);
 	    device = g_strdup(cmdargs->argv[a++]);
 	    b64device = amxml_format_tag("diskdevice", device);
-	    if(strcmp(device,"NODEVICE") == 0)
+	    if(g_str_equal(device, "NODEVICE"))
 		amfree(device);
 
 	    if(a >= cmdargs->argc) {
@@ -816,7 +816,7 @@ parse_info_line(
     char *name, *value;
     size_t i;
 
-    if (strcmp(str, "end") == 0) {
+    if (g_str_equal(str, "end")) {
 	SET(status, GOT_INFO_ENDLINE);
 	return;
     }
@@ -829,7 +829,7 @@ parse_info_line(
 	return;
 
     for (i = 0; i < sizeof(fields) / sizeof(fields[0]); i++) {
-	if (strcmp(name, fields[i].name) == 0) {
+	if (g_str_equal(name, fields[i].name)) {
 	    strncpy(fields[i].value, value, fields[i].len - 1);
 	    fields[i].value[fields[i].len - 1] = '\0';
 	    break;
@@ -856,18 +856,18 @@ process_dumpline(
     case 's':
 	/* a sendbackup line, just check them all since there are only 5 */
 	tok = strtok(buf, " ");
-	if (tok == NULL || strcmp(tok, "sendbackup:") != 0)
+	if (tok == NULL || !g_str_equal(tok, "sendbackup:"))
 	    goto bad_line;
 
 	tok = strtok(NULL, " ");
 	if (tok == NULL)
 	    goto bad_line;
 
-	if (strcmp(tok, "start") == 0) {
+	if (g_str_equal(tok, "start")) {
 	    break;
 	}
 
-	if (strcmp(tok, "size") == 0) {
+	if (g_str_equal(tok, "size")) {
 	    tok = strtok(NULL, "");
 	    if (tok != NULL) {
 		origsize = OFF_T_ATOI(tok);
@@ -876,22 +876,22 @@ process_dumpline(
 	    break;
 	}
 
-	if (strcmp(tok, "no-op") == 0) {
+	if (g_str_equal(tok, "no-op")) {
 	    amfree(buf);
 	    return;
 	}
 
-	if (strcmp(tok, "end") == 0) {
+	if (g_str_equal(tok, "end")) {
 	    SET(status, GOT_ENDLINE);
 	    break;
 	}
 
-	if (strcmp(tok, "warning") == 0) {
+	if (g_str_equal(tok, "warning")) {
 	    dump_result = max(dump_result, 1);
 	    break;
 	}
 
-	if (strcmp(tok, "error") == 0) {
+	if (g_str_equal(tok, "error")) {
 	    SET(status, GOT_ENDLINE);
 	    dump_result = max(dump_result, 2);
 
@@ -913,7 +913,7 @@ process_dumpline(
 	    break;
 	}
 
-	if (strcmp(tok, "info") == 0) {
+	if (g_str_equal(tok, "info")) {
 	    tok = strtok(NULL, "");
 	    if (tok != NULL)
 		parse_info_line(tok);
@@ -2089,7 +2089,7 @@ sendbackup_response(
 #endif
 
 	tok = strtok(pkt->body, " ");
-	if (tok == NULL || strcmp(tok, "ERROR") != 0)
+	if (tok == NULL || !g_str_equal(tok, "ERROR"))
 	    goto bad_nak;
 
 	tok = strtok(NULL, "\n");
@@ -2129,7 +2129,7 @@ bad_nak:
 	 * Error response packets have "ERROR" followed by the error message
 	 * followed by a newline.
 	 */
-	if (strcmp(tok, "ERROR") == 0) {
+	if (g_str_equal(tok, "ERROR")) {
 	    tok = strtok(NULL, "\n");
 	    if (tok == NULL)
 		tok = _("[bogus error packet]");
@@ -2142,14 +2142,14 @@ bad_nak:
 	/*
 	 * Regular packets have CONNECT followed by three streams
 	 */
-	if (strcmp(tok, "CONNECT") == 0) {
+	if (g_str_equal(tok, "CONNECT")) {
 
 	    /*
 	     * Parse the three stream specifiers out of the packet.
 	     */
 	    for (i = 0; i < NSTREAMS; i++) {
 		tok = strtok(NULL, " ");
-		if (tok == NULL || strcmp(tok, streams[i].name) != 0) {
+		if (tok == NULL || !g_str_equal(tok, streams[i].name)) {
 		    extra = g_strdup_printf(
 				_("CONNECT token is \"%s\": expected \"%s\""),
 				tok ? tok : "(null)",
@@ -2170,7 +2170,7 @@ bad_nak:
 	/*
 	 * OPTIONS [options string] '\n'
 	 */
-	if (strcmp(tok, "OPTIONS") == 0) {
+	if (g_str_equal(tok, "OPTIONS")) {
 	    tok = strtok(NULL, "\n");
 	    if (tok == NULL) {
 		extra = g_strdup(_("OPTIONS token is missing"));
@@ -2273,19 +2273,19 @@ dumper_get_security_conf(
         if(!string || !*string)
                 return(NULL);
 
-        if(strcmp(string, "krb5principal")==0) {
+        if(g_str_equal(string, "krb5principal")) {
                 return(getconf_str(CNF_KRB5PRINCIPAL));
-        } else if(strcmp(string, "krb5keytab")==0) {
+        } else if(g_str_equal(string, "krb5keytab")) {
                 return(getconf_str(CNF_KRB5KEYTAB));
-        } else if(strcmp(string, "amandad_path")==0) {
+        } else if(g_str_equal(string, "amandad_path")) {
                 return (amandad_path);
-        } else if(strcmp(string, "client_username")==0) {
+        } else if(g_str_equal(string, "client_username")) {
                 return (client_username);
-        } else if(strcmp(string, "client_port")==0) {
+        } else if(g_str_equal(string, "client_port")) {
                 return (client_port);
-        } else if(strcmp(string, "ssh_keys")==0) {
+        } else if(g_str_equal(string, "ssh_keys")) {
                 return (ssh_keys);
-        } else if(strcmp(string, "kencrypt")==0) {
+        } else if(g_str_equal(string, "kencrypt")) {
 		if (dumper_kencrypt == KENCRYPT_YES)
                     return ("yes");
 		else
@@ -2340,8 +2340,8 @@ startup_dump(
      */
 
     g_snprintf(level_string, sizeof(level_string), "%d", level);
-    if(strcmp(progname, "DUMP") == 0
-       || strcmp(progname, "GNUTAR") == 0) {
+    if(g_str_equal(progname, "DUMP")
+       || g_str_equal(progname, "GNUTAR")) {
 	application_api = "";
     } else {
 	application_api = "BACKUP ";

--- a/server-src/find.c
+++ b/server-src/find.c
@@ -76,7 +76,7 @@ find_result_t * find_dump(disklist_t* diskqp) {
 	for (tape1 = tape; tape1 <= maxtape; tape1++) {
 	    tp1 = lookup_tapepos(tape1);
 	    if (tp1 == NULL) continue;
-	    if (strcmp(tp->datestamp, tp1->datestamp) != 0)
+	    if (!g_str_equal(tp->datestamp, tp1->datestamp))
 		continue;
 
 	    tape_seen[tape1] = 1;
@@ -173,7 +173,8 @@ find_log(void)
 	    pathlogfile = g_strconcat(conf_logdir, "/", logfile, NULL);
 	    if (access(pathlogfile, R_OK) != 0) break;
 	    if (logfile_has_tape(tp->label, tp->datestamp, pathlogfile)) {
-		if (current_log == output_find_log || strcmp(*(current_log-1), logfile)) {
+		if (current_log == output_find_log || !g_str_equal(*(current_log - 1),
+                                                                   logfile)) {
 		    *current_log = g_strdup(logfile);
 		    current_log++;
 		}
@@ -191,7 +192,8 @@ find_log(void)
 	pathlogfile = g_strconcat(conf_logdir, "/", logfile, NULL);
 	if (access(pathlogfile, R_OK) == 0) {
 	    if (logfile_has_tape(tp->label, tp->datestamp, pathlogfile)) {
-		if (current_log == output_find_log || strcmp(*(current_log-1), logfile)) {
+		if (current_log == output_find_log || !g_str_equal(*(current_log - 1),
+                                                                   logfile)) {
 		    *current_log = g_strdup(logfile);
 		    current_log++;
 		}
@@ -207,7 +209,8 @@ find_log(void)
 	pathlogfile = g_strconcat(conf_logdir, "/", logfile, NULL);
 	if (access(pathlogfile, R_OK) == 0) {
 	    if (logfile_has_tape(tp->label, tp->datestamp, pathlogfile)) {
-		if (current_log == output_find_log || strcmp(*(current_log-1), logfile)) {
+		if (current_log == output_find_log || !g_str_equal(*(current_log - 1),
+                                                                   logfile)) {
 		    *current_log = g_strdup(logfile);
 		    current_log++;
 		}
@@ -215,7 +218,7 @@ find_log(void)
 	    }
 	}
 
-	if(logs == 0 && strcmp(tp->datestamp,"0") != 0)
+	if(logs == 0 && !g_str_equal(tp->datestamp, "0"))
 	    g_fprintf(stderr, _("Warning: no log files found for tape %s written %s\n"),
 		   tp->label, find_nicedate(tp->datestamp));
     }
@@ -488,8 +491,8 @@ print_find_result(
 	    else
 		formatted_label = quote_string(output_find_result->label);
 
-	    if (strcmp(output_find_result->status, "OK") != 0 ||
-		strcmp(output_find_result->dump_status, "OK") != 0) {
+	    if (!g_str_equal(output_find_result->status, "OK") ||
+		!g_str_equal(output_find_result->dump_status, "OK")) {
 		status = g_strjoin(NULL, output_find_result->status, " ",
 				   output_find_result->dump_status, NULL);
 	    } else {
@@ -659,8 +662,8 @@ static gboolean logfile_has_tape(char * label, char * datestamp,
 					 &ck_datestamp, &ck_label) == 0) {
 		g_printf(_("strange log line \"start taper %s\" curstr='%s'\n"),
                          logfile, curstr);
-	    } else if(strcmp(ck_datestamp, datestamp) == 0
-		      && strcmp(ck_label, label) == 0) {
+	    } else if(g_str_equal(ck_datestamp, datestamp)
+		      && g_str_equal(ck_label, label)) {
 		amfree(ck_label);
                 afclose(logf);
                 return TRUE;
@@ -685,13 +688,13 @@ volume_matches(
 	return TRUE;
 
     if (label1)
-	return (strcmp(label1, label2) == 0);
+	return (g_str_equal(label1, label2));
 
     /* check in tapelist */
     if (!(tp = lookup_tapelabel(label2)))
 	return FALSE;
 
-    if (strcmp(tp->datestamp, datestamp) != 0)
+    if (!g_str_equal(tp->datestamp, datestamp))
 	return FALSE;
 
     return TRUE;
@@ -763,7 +766,7 @@ search_logfile(
                 continue;
 	    }
             if (datestamp != NULL) {
-                if (strcmp(datestamp, ck_datestamp) != 0) {
+                if (!g_str_equal(datestamp, ck_datestamp)) {
                     g_printf(_("Log file %s stamped %s, expecting %s!\n"),
                              logfile, ck_datestamp, datestamp);
 		    amfree(ck_label);
@@ -932,7 +935,7 @@ search_logfile(
 	    skip_non_whitespace(s, ch);
 	    rest_undo = s - 1;
 	    *rest_undo = '\0';
-	    if (strcmp(rest, "[sec") == 0) {
+	    if (g_str_equal(rest, "[sec")) {
 		skip_whitespace(s, ch);
 		if(ch == '\0') {
 		    g_printf(_("strange log line in %s \"%s\"\n"),
@@ -947,8 +950,8 @@ search_logfile(
 		skip_non_whitespace(s, ch);
 		rest_undo = s - 1;
 		*rest_undo = '\0';
-		if (strcmp(rest, "kb") != 0 &&
-		    strcmp(rest, "bytes") != 0) {
+		if (!g_str_equal(rest, "kb") &&
+		    !g_str_equal(rest, "bytes")) {
 		    g_printf(_("Bstrange log line in %s \"%s\"\n"),
 			     logfile, curstr);
 		    amfree(disk);
@@ -962,7 +965,7 @@ search_logfile(
 		     amfree(disk);
 		     continue;
 		}
-		if (strcmp(rest, "kb") == 0) {
+		if (g_str_equal(rest, "kb")) {
 		    kb = atof(s - 1);
 		    bytes = 0;
 		} else {
@@ -975,7 +978,7 @@ search_logfile(
 		skip_non_whitespace(s, ch);
 		rest_undo = s - 1;
 		*rest_undo = '\0';
-		if (strcmp(rest, "kps") != 0) {
+		if (!g_str_equal(rest, "kps")) {
 		    g_printf(_("Cstrange log line in %s \"%s\"\n"),
 			     logfile, curstr);
 		    amfree(disk);
@@ -996,7 +999,7 @@ search_logfile(
 		skip_non_whitespace(s, ch);
 		rest_undo = s - 1;
 		*rest_undo = '\0';
-		if (strcmp(rest, "orig-kb") != 0) {
+		if (!g_str_equal(rest, "orig-kb")) {
 		    orig_kb = 0;
 		} else {
 
@@ -1017,8 +1020,8 @@ search_logfile(
 		*rest_undo = ' ';
 	    }
 
-	    if (strncmp(rest, "error", 5) == 0) rest += 6;
-	    if (strncmp(rest, "config", 6) == 0) rest += 7;
+	    if (g_str_has_prefix(rest, "error")) rest += 6;
+	    if (g_str_has_prefix(rest, "config")) rest += 7;
 
 	    dp = lookup_disk(host,disk);
 	    if ( dp == NULL ) {
@@ -1094,7 +1097,7 @@ search_logfile(
 				     a_part_find;
 				     a_part_find = a_part_find->next) {
 				    if (a_part_find->partnum == num_part &&
-					strcmp(a_part_find->status, "OK") == 0)
+					g_str_equal(a_part_find->status, "OK"))
 					num_part--;
 			        }
 				/* set dump_status of each part */
@@ -1238,8 +1241,8 @@ dumps_match(
 	   (!diskname || *diskname == '\0' || match_disk(diskname, cur_result->diskname)) &&
 	   (!datestamp || *datestamp== '\0' || match_datestamp(datestamp, cur_result->timestamp)) &&
 	   (!level || *level== '\0' || match_level(level, level_str)) &&
-	   (!ok || !strcmp(cur_result->status, "OK")) &&
-	   (!ok || !strcmp(cur_result->dump_status, "OK"))){
+	   (!ok || g_str_equal(cur_result->status, "OK")) &&
+	   (!ok || g_str_equal(cur_result->dump_status, "OK"))){
 
 	    find_result_t *curmatch = g_new0(find_result_t, 1);
 	    memcpy(curmatch, cur_result, sizeof(find_result_t));
@@ -1317,8 +1320,8 @@ dumps_match_dumpspecs(
 			|| match_datestamp(ds->write_timestamp, cur_result->write_timestamp)
 			|| (zeropad_w_ts && match_datestamp(ds->write_timestamp, zeropad_w_ts))) &&
 	       (!ds->level || *ds->level== '\0' || match_level(ds->level, level_str)) &&
-	       (!ok || !strcmp(cur_result->status, "OK")) &&
-	       (!ok || !strcmp(cur_result->dump_status, "OK"))) {
+	       (!ok || g_str_equal(cur_result->status, "OK")) &&
+	       (!ok || g_str_equal(cur_result->dump_status, "OK"))) {
 
 		find_result_t *curmatch = g_malloc(sizeof(find_result_t));
 		memcpy(curmatch, cur_result, sizeof(find_result_t));
@@ -1361,9 +1364,9 @@ dump_exist(
     for(output_find_result=output_find;
 	output_find_result;
 	output_find_result=output_find_result->next) {
-	if( !strcmp(output_find_result->hostname, hostname) &&
-	    !strcmp(output_find_result->diskname, diskname) &&
-	    !strcmp(output_find_result->timestamp, datestamp) &&
+	if(g_str_equal(output_find_result->hostname, hostname) &&
+	    g_str_equal(output_find_result->diskname, diskname) &&
+	    g_str_equal(output_find_result->timestamp, datestamp) &&
 	    output_find_result->level == level) {
 
 	    return output_find_result;

--- a/server-src/holding.c
+++ b/server-src/holding.c
@@ -344,7 +344,7 @@ holding_walk_disk(
 	    is_cruft = 1;
         } else if (!is_datestr(workdir->d_name)) {
             /* EXT2/3 leave these in the root of each volume */
-            if (strcmp(workdir->d_name, "lost+found") == 0)
+            if (g_str_equal(workdir->d_name, "lost+found"))
 		continue; /* expected cruft */
 	    else
 		is_cruft = 1; /* unexpected */
@@ -535,7 +535,7 @@ holding_get_files_for_flush(
 	    date_matches = 0;
 	    /* loop over date args, until we find a match */
 	    for (date = dateargs; date !=NULL; date = date->next) {
-		if (strcmp((char *)date->data, file.datestamp) == 0) {
+		if (g_str_equal((char *)date->data, file.datestamp)) {
 		    date_matches = 1;
 		    break;
 		}
@@ -799,7 +799,7 @@ holding_cleanup_file(
 	return 0;
     }
 
-    if ((l = strlen(element)) >= 7 && strncmp(&fqpath[l-4],".tmp",4) == 0) {
+    if ((l = strlen(element)) >= 7 && g_str_has_prefix(&fqpath[l - 4], ".tmp")) {
 	char *destname;
 
 	/* generate a name without '.tmp' */

--- a/server-src/list_dir.c
+++ b/server-src/list_dir.c
@@ -89,8 +89,8 @@ add_dir_list_item(
 	return 0; /* added */
     }
 
-    if (strcmp(path, "/") != 0 &&
-	strcmp(path, dir_last->path) == 0) {
+    if (!g_str_equal(path, "/") &&
+	g_str_equal(path, dir_last->path)) {
 	return 0; /* found */
     }
 
@@ -115,7 +115,7 @@ add_dir_list_item(
 	if(strcmp(path,cur_list->path) < 0)
 	    cur_list=dir_list;
 
-	if(strcmp(path,cur_list->path) == 0)
+	if(g_str_equal(path, cur_list->path))
 	    return 0; /* found */
 
 	while (cur_list->next!=NULL && (strcmp(path,cur_list->next->path) > 0))
@@ -123,7 +123,7 @@ add_dir_list_item(
 	    cur_list=cur_list->next;
 	}
 
-	if (cur_list->next && strcmp(path, cur_list->next->path) == 0)
+	if (cur_list->next && g_str_equal(path, cur_list->next->path))
 	{
 	    cur_list=cur_list->next;
 	    return 0; /* found */

--- a/server-src/logfile.c
+++ b/server-src/logfile.c
@@ -319,10 +319,10 @@ get_logline(
     /* lookup strings */
 
     for(curlog = L_MARKER; curlog != L_BOGUS; curlog--)
-	if(strcmp(logtype_str[curlog], logstr) == 0) break;
+	if(g_str_equal(logtype_str[curlog], logstr)) break;
 
     for(curprog = P_LAST; curprog != P_UNKNOWN; curprog--)
-	if(strcmp(program_str[curprog], progstr) == 0) break;
+	if(g_str_equal(program_str[curprog], progstr)) break;
 
     return 1;
 }

--- a/server-src/planner.c
+++ b/server-src/planner.c
@@ -257,15 +257,18 @@ main(
 	g_fprintf(stderr, _("%s: %s"), get_pname(), version_info[i]);
 
     diskarg_offset = 2;
-    if (argc - diskarg_offset > 1 && strcmp(argv[diskarg_offset], "--starttime") == 0) {
+    if (argc - diskarg_offset > 1 && g_str_equal(argv[diskarg_offset],
+                                                 "--starttime")) {
 	planner_timestamp = g_strdup(argv[diskarg_offset+1]);
 	diskarg_offset += 2;
     }
-    if (argc - diskarg_offset > 0 && strcmp(argv[diskarg_offset], "--no-taper") == 0) {
+    if (argc - diskarg_offset > 0 && g_str_equal(argv[diskarg_offset],
+                                                 "--no-taper")) {
 	no_taper = TRUE;
 	diskarg_offset += 1;
     }
-    if (argc - diskarg_offset > 0 && strcmp(argv[diskarg_offset], "--from-client") == 0) {
+    if (argc - diskarg_offset > 0 && g_str_equal(argv[diskarg_offset],
+                                                 "--from-client")) {
 	from_client = TRUE;
 	diskarg_offset += 1;
     }
@@ -1732,8 +1735,8 @@ static void getsize(am_host_t *hostp)
             estimates_for_client = i;
 
             g_ptr_array_add(array, client_estimate_as_xml(dp, features, estimates_for_client));
-        } else if (strcmp(dp->program,"DUMP") != 0 &&
-                   strcmp(dp->program,"GNUTAR") != 0) {
+        } else if (!g_str_equal(dp->program, "DUMP") &&
+                   !g_str_equal(dp->program, "GNUTAR")) {
             g_free(est(dp)->errstr);
             est(dp)->errstr = g_strdup("does not support application-api");
         } else {
@@ -1848,7 +1851,7 @@ static disk_t *lookup_hostdisk(
     disk_t *dp;
 
     for(dp = hp->disks; dp != NULL; dp = dp->hostnext)
-	if(strcmp(str, dp->name) == 0) return dp;
+	if(g_str_equal(str, dp->name)) return dp;
 
     return NULL;
 }
@@ -1879,7 +1882,7 @@ static void handle_result(
     hostp->up = HOST_READY;
 
     if (pkt == NULL) {
-	if (strcmp(security_geterror(sech), "timeout waiting for REP") == 0) {
+	if (g_str_equal(security_geterror(sech), "timeout waiting for REP")) {
 	    errbuf = g_strdup_printf("Some estimate timeout on %s, using server estimate if possible", hostp->hostname);
 	} else {
 	    errbuf = g_strdup_printf(_("Request to %s failed: %s"),
@@ -1901,8 +1904,8 @@ static void handle_result(
 	    if(s == remoterr) goto NAK_parse_failed;
 		*s = '\0';
 	}
-	if (strcmp(remoterr, "unknown service: noop") != 0
-		&& strcmp(remoterr, "noop: invalid service") != 0) {
+	if (!g_str_equal(remoterr, "unknown service: noop")
+		&& !g_str_equal(remoterr, "noop: invalid service")) {
 	    errbuf = g_strjoin(NULL, hostp->hostname, " NAK: ", remoterr, NULL);
 	    if(s) *s = '\n';
 	    goto error_return;
@@ -1951,8 +1954,8 @@ static void handle_result(
 	     */
 	    if(hostp->features == NULL
 	       && pkt->type == P_NAK
-	       && (strcmp(t - 1, "unknown service: noop") == 0
-		   || strcmp(t - 1, "noop: invalid service") == 0)) {
+	       && (g_str_equal(t - 1, "unknown service: noop")
+		   || g_str_equal(t - 1, "noop: invalid service"))) {
 		skip_quoted_line(s, ch);
 		continue;
 	    }
@@ -2920,7 +2923,7 @@ static int promote_highest_priority_incremental(void)
 		nb_disk_today++;
 	    else if(est(dp1)->next_level0 == est(dp)->next_level0)
 		nb_disk_same_day++;
-	    if(strcmp(dp->host->hostname, dp1->host->hostname) == 0) {
+	    if(g_str_equal(dp->host->hostname, dp1->host->hostname)) {
 		if(est(dp1)->dump_est->level == 0)
 		    nb_today++;
 		else if(est(dp1)->next_level0 == est(dp)->next_level0)

--- a/server-src/server_util.c
+++ b/server-src/server_util.c
@@ -85,7 +85,7 @@ getcmd(void)
     }
 
     for(cmd_i=BOGUS; cmdstr[cmd_i] != NULL; cmd_i++)
-	if(strcmp(cmdargs->argv[0], cmdstr[cmd_i]) == 0) {
+	if(g_str_equal(cmdargs->argv[0], cmdstr[cmd_i])) {
 	    cmdargs->cmd = cmd_i;
 	    return cmdargs;
 	}
@@ -143,20 +143,20 @@ amhost_get_security_conf(
     if(!string || !*string)
 	return(NULL);
 
-    if(strcmp(string, "krb5principal")==0)
+    if(g_str_equal(string, "krb5principal"))
 	return(getconf_str(CNF_KRB5PRINCIPAL));
-    else if(strcmp(string, "krb5keytab")==0)
+    else if(g_str_equal(string, "krb5keytab"))
 	return(getconf_str(CNF_KRB5KEYTAB));
 
     if(!arg || !((am_host_t *)arg)->disks) return(NULL);
 
-    if(strcmp(string, "amandad_path")==0)
+    if(g_str_equal(string, "amandad_path"))
 	return ((am_host_t *)arg)->disks->amandad_path;
-    else if(strcmp(string, "client_username")==0)
+    else if(g_str_equal(string, "client_username"))
 	return ((am_host_t *)arg)->disks->client_username;
-    else if(strcmp(string, "client_port")==0)
+    else if(g_str_equal(string, "client_port"))
 	return ((am_host_t *)arg)->disks->client_port;
-    else if(strcmp(string, "ssh_keys")==0)
+    else if(g_str_equal(string, "ssh_keys"))
 	return ((am_host_t *)arg)->disks->ssh_keys;
 
     return(NULL);
@@ -196,7 +196,7 @@ int check_infofile(
 		    char *Xdiskdir     = sanitise_filename(diskp->name);
 		    char *Xinfofile = g_strjoin(NULL, infodir, "/", Xhostinfodir, "/",
 					  Xdiskdir, "/info", NULL);
-		    if (strcmp(old_infofile, Xinfofile) == 0) {
+		    if (g_str_equal(old_infofile, Xinfofile)) {
 			other_dle_match = 1;
 			diskp = NULL;
 		    }

--- a/server-src/tapefile.c
+++ b/server-src/tapefile.c
@@ -145,7 +145,7 @@ lookup_tapelabel(
     tape_t *tp;
 
     for(tp = tape_list; tp != NULL; tp = tp->next) {
-	if(strcmp(label, tp->label) == 0) return tp;
+	if(g_str_equal(label, tp->label)) return tp;
     }
     return NULL;
 }
@@ -172,7 +172,7 @@ lookup_tapedate(
     tape_t *tp;
 
     for(tp = tape_list; tp != NULL; tp = tp->next) {
-	if(strcmp(tp->datestamp, datestamp) == 0) return tp;
+	if(g_str_equal(tp->datestamp, datestamp)) return tp;
     }
     return NULL;
 }
@@ -219,7 +219,7 @@ lookup_last_reusable_tape(
 	tpsave[s] = NULL;
     }
     for(tp = tape_list; tp != NULL; tp = tp->next) {
-	if(tp->reuse == 1 && strcmp(tp->datestamp,"0") != 0 && match (labelstr, tp->label)) {
+	if(tp->reuse == 1 && !g_str_equal(tp->datestamp, "0") && match (labelstr, tp->label)) {
 	    count++;
 	    for(s = skip; s > 0; s--) {
 	        tpsave[s] = tpsave[s - 1];
@@ -243,7 +243,7 @@ reusable_tape(
 
     if(tp == NULL) return 0;
     if(tp->reuse == 0) return 0;
-    if( strcmp(tp->datestamp,"0") == 0) return 1;
+    if(g_str_equal(tp->datestamp, "0")) return 1;
     while(tp != NULL) {
 	if(tp->reuse == 1) count++;
 	tp = tp->prev;
@@ -518,11 +518,11 @@ list_new_tapes(
     while (lasttp && lasttp->reuse == 0)
 	lasttp = lasttp->prev;
 
-    if(lasttp && nb > 0 && strcmp(lasttp->datestamp,"0") == 0) {
+    if(lasttp && nb > 0 && g_str_equal(lasttp->datestamp, "0")) {
 	int c = 0;
 	iter = lasttp;
 	/* count the number of tapes we *actually* used */
-	while(iter && nb > 0 && strcmp(iter->datestamp,"0") == 0) {
+	while(iter && nb > 0 && g_str_equal(iter->datestamp, "0")) {
 	    if (iter->reuse) {
 		c++;
 		nb--;
@@ -540,7 +540,7 @@ list_new_tapes(
 			c, lasttp->label);
 	    iter = lasttp->prev;
 	    c--;
-	    while(iter && c > 0 && strcmp(iter->datestamp,"0") == 0) {
+	    while(iter && c > 0 && g_str_equal(iter->datestamp, "0")) {
 		if (iter->reuse) {
 		    result = vstrextend(&result, ", ", iter->label, NULL);
 		    c--;


### PR DESCRIPTION
GLib has g_str_equal() and g_str_has_prefix(), which are much easier to use than
strcmp(...) == 0 or strncmp(e1, e2, len) == 0. Use them. The following semantic
patch found and replaced all occurrences:

<pre>
@@
expression e1, e2, e3;
@@

(
- strncmp(e1, e2, e3) == 0
+ g_str_has_prefix(e1, e2)
|
- strcmp(e1, e2) == 0
+ g_str_equal(e1, e2)
|
- strncmp(e1, e2, e3) != 0
+ !g_str_has_prefix(e1, e2)
|
- strcmp(e1, e2) != 0
+ !g_str_equal(e1, e2)
)
</pre>
