### PR TITLE
Allow amrecover to display and use utf-8 characters.

### DIFF
--- a/recover-src/amrecover.c
+++ b/recover-src/amrecover.c
@@ -65,6 +65,7 @@ char *disk_name = NULL;			/* disk we are restoring */
 dle_t *dump_dle = NULL;
 char *mount_point = NULL;		/* where disk was mounted */
 char *disk_path = NULL;			/* path relative to mount point */
+char *disk_tpath = NULL;		/* translated path relative to mount point */
 char dump_date[STR_SIZE];		/* date on which we are restoring */
 int quit_prog;				/* set when time to exit parser */
 char *tape_server_name = NULL;
@@ -273,7 +274,7 @@ sigint_handler(
 }
 
 
-void
+char *
 clean_pathname(
     char *	s)
 {
@@ -291,6 +292,8 @@ clean_pathname(
     /* remove "/." at end of path */
     if(g_str_equal(&(s[length - 2]), "/."))
 	s[length-2]='\0';
+
+    return s;
 }
 
 
@@ -488,6 +491,7 @@ main(
     amfree(disk_name);
     amfree(mount_point);
     amfree(disk_path);
+    amfree(disk_tpath);
     dump_date[0] = '\0';
 
     /* Don't die when child closes pipe */
@@ -840,3 +844,35 @@ stop_amindexd(void)
         }
     }
 }
+
+
+char *
+translate_octal(
+    char *line)
+{
+    char *s = line, *s1, *s2;
+    char *p = line;
+    int i;
+
+    while(*s != '\0') {
+	if ((s == line || *(s-1) != '\\') && *s == '\\') {
+	    s++;
+	    s1 = s+1;
+	    s2 = s+2;
+	    if (isdigit(*s) && *s1 != '\0' && isdigit(*s1) && isdigit(*s2)) {
+		i = ((*s)-'0')*64 + ((*s1)-'0')*8 + ((*s2)-'0');
+		*p++ = i;
+		s += 3;
+	    } else {
+		*p++ = *s++;
+	    }
+
+	} else {
+	    *p++ = *s++;
+	}
+    }
+    *p = '\0';
+
+    return line;
+}
+

--- a/recover-src/amrecover.h
+++ b/recover-src/amrecover.h
@@ -42,6 +42,7 @@ typedef struct DIR_ITEM
     int  level;
     char *tape;
     char *path;
+    char *tpath; /* translated path */
     off_t  fileno;
 
     struct DIR_ITEM *next;
@@ -56,6 +57,7 @@ extern char *disk_name;			/* disk we are restoring */
 extern dle_t *dump_dle;
 extern char *mount_point;		/* where disk was mounted */
 extern char *disk_path;			/* path relative to mount point */
+extern char *disk_tpath;		/* translated path relative to mount point */
 extern char dump_date[STR_SIZE];	/* date on which we are restoring */
 extern int quit_prog;			/* set when time to exit parser */
 extern char *tape_server_name;
@@ -93,6 +95,7 @@ extern int cd_regex(char *dir, int verbose);
 extern int cd_dir(char *dir, char *default_dir, int verbose);
 extern void set_tape(char *tape);
 extern void set_device(char *host, char *device);
+extern void set_translate(char *translate);
 extern void show_directory(void);
 extern void set_mode(int mode);
 extern void show_mode(void);
@@ -106,7 +109,7 @@ extern DIR_ITEM *get_dir_list(void);
 extern DIR_ITEM *get_next_dir_item(DIR_ITEM *this);
 extern void suck_dir_list_from_server(void);
 extern void clear_dir_list(void);
-extern void clean_pathname(char *s);
+extern char *clean_pathname(char *s);
 extern void display_extract_list(char *file);
 extern void clear_extract_list(void);
 extern int is_extract_list_nonempty(void);
@@ -124,3 +127,4 @@ extern void extract_files(void);
 
 extern char *get_security(void);
 extern void stop_amindexd(void);
+extern char *translate_octal(char *line);

--- a/recover-src/display_commands.c
+++ b/recover-src/display_commands.c
@@ -33,6 +33,8 @@
 #include "amrecover.h"
 #include "util.h"
 
+gboolean translate_mode = FALSE;
+
 DIR_ITEM *get_dir_list(void);
 DIR_ITEM *get_next_dir_item(DIR_ITEM *this);
 
@@ -83,6 +85,7 @@ free_dir_item(
         amfree(item->date);
         amfree(item->tape);
         amfree(item->path);
+        amfree(item->tpath);
         amfree(item);
 	item = next;
     }
@@ -110,6 +113,7 @@ add_dir_list_item(
     next->tape = g_strdup(tape);
     next->fileno = fileno;
     next->path = g_strdup(path);
+    next->tpath = translate_octal(g_strdup(path));
 
     next->next = dir_list;
     dir_list = next;
@@ -319,7 +323,7 @@ list_directory(void)
     if (i != 1)
 	i++;				/* so disk_path != "/" */
     for (item = get_dir_list(); item != NULL; item=get_next_dir_item(item)) {
-	quoted = quote_string(item->path + i);
+	quoted = quote_string(item->tpath + i);
 	g_fprintf(fp, "%s %s\n", item->date, quoted);
 	amfree(quoted);
     }

--- a/recover-src/uparse.y
+++ b/recover-src/uparse.y
@@ -53,7 +53,7 @@ extern char *	yytext;
 %token SETHOST SETDISK SETDATE SETTAPE SETMODE SETDEVICE SETPROPERTY
 %token CD CDX QUIT DHIST LS ADD ADDX EXTRACT DASH_H
 %token LIST DELETE DELETEX PWD CLEAR HELP LCD LPWD MODE SMB TAR
-%token APPEND PRIORITY
+%token APPEND PRIORITY SETTRANSLATE
 %token NL
 
         /* typed tokens */
@@ -87,6 +87,9 @@ set_command:
   |	LISTDISK STRING invalid_string { yyerror("Invalid argument"); amfree($2); }
   |	LISTPROPERTY NL { list_property(); }
   |	LISTPROPERTY invalid_string { yyerror("Invalid argument"); }
+  |	SETTRANSLATE NL { set_translate(NULL); }
+  |	SETTRANSLATE STRING invalid_string NL { yyerror("Invalid argument"); }
+  |	SETTRANSLATE STRING NL { set_translate($2); amfree($2); }
   |	SETHOST STRING NL { set_host($2); amfree($2); }
   |	SETHOST STRING invalid_string { yyerror("Invalid argument"); amfree($2); }
   |	SETHOST NL { yyerror("Argument required"); }

--- a/recover-src/uscan.l
+++ b/recover-src/uscan.l
@@ -82,6 +82,7 @@ setmode		{ BEGIN(needmode); return SETMODE; }
 settape		{ BEGIN(needstring); return SETTAPE; }
 setdevice	{ BEGIN(needdevice); return SETDEVICE; }
 setproperty	{ BEGIN(propertyappend); return SETPROPERTY; }
+settranslate	{ BEGIN(needstring); return SETTRANSLATE; }
 <needdevice>-h	{ BEGIN(needstring); return DASH_H; }
 cd		{ BEGIN(needstring); return CD; }
 cdx		{ BEGIN(needstring); return CDX; }


### PR DESCRIPTION
Add a settranslate command to amrecover
If set to on, it translate all octal '\000' in filename to the corresponding byte value.
If you run amrecover in the same locale as the filename then you see the correct characters.
This is done by keeping a copy off all translated filename (tpath) and using them in the amrecover interface.
Communication with amindexd is still done with non-translated filename.

Maybe settranslate should be on by default? It make no difference if you have no characters with the eighth bit set.
