### PR TITLE
server-src/amcheck/c: fix test in check_tapefile()

### DIFF
--- a/server-src/amcheck.c
+++ b/server-src/amcheck.c
@@ -551,9 +551,9 @@ int check_tapefile(
 		    quoted);
 	    tapebad = 1;
 	    amfree(quoted);
-	} else if (access(tapefile, F_OK) != 0) {
+	} else if (access(tapefile, R_OK) != 0) {
 	    quoted = quote_string(tapefile);
-	    g_fprintf(outf, _("ERROR: can't access tapelist %s\n"), quoted);
+	    g_fprintf(outf, _("ERROR: tapelist %s: not readable\n"), quoted);
 	    tapebad = 1;
 	    amfree(quoted);
 	} else if (access(tapefile, W_OK) != 0) {


### PR DESCRIPTION
In this function, stat(2) was called to a file. The next test, if stat(2)
returned 0, was then to check whether the file was a regular file.

The test after that was access(..., F_OK). But that is redundant: if this were
not the case, stat(2) would have returned -1 anyway. This test is therefore
meaningless.

Assume here that R_OK was meant instead, ie that the file is readable by the
user running amcheck. Correct wording of the following error message if
access(2) does not return 0.
