### PR TITLE
Better size estimate for samba...

### DIFF
--- a/application-src/amsamba.pl
+++ b/application-src/amsamba.pl
@@ -510,9 +510,9 @@ sub command_estimate {
 	    push @ARGV, "-D", $self->{subdir},
 	}
 	if ($level == 0) {
-	    push @ARGV, "-c", "archive 0;recurse;du";
+	    push @ARGV, "-c", "archive 1;recurse;du /" . $self->{subdir};
 	} else {
-	    push @ARGV, "-c", "archive 1;recurse;du";
+	    push @ARGV, "-c", "archive 1;recurse;du /" . $self->{subdir};
 	}
 	debug("execute: " . $self->{smbclient} . " " .
 	      join(" ", @ARGV));


### PR DESCRIPTION
When DLE has a subdir, the estimate was taking too much time, because it was executing in ROOT of the share (even using -D subdir), now it will execute only in the subdir.

On the share's root (only to see the total amount of data):

```
/opt/apps/samba4/bin/smbclient //localhost/test  -d 0 -U guest -E -c "archive 0;recurse;du"
Total number of bytes: 144090056
```

Original code of amanda when estimate size of //localhost/test/subdir:

```
/opt/apps/samba4/bin/smbclient //localhost/test  -d 0 -U guest -E -D subdir -c "archive 0;recurse;du"
Total number of bytes: 144090056

```

With this patch when estimate size of //localhost/test/subdir:

```
/opt/apps/samba4/bin/smbclient //localhost/test  -d 0 -U guest -E -D subdir -c "archive 0;recurse;du /subdir"
Total number of bytes: 72045028
```

```
-bash-4.1$ du -s /tmp/test
159832  /tmp/test
-bash-4.1$ du -s /tmp/test/*
79920   /tmp/test/pasta
79908   /tmp/test/subdir
```

Tested with samba3 and samba4, same behavior.

Wagner Caixeta Rodrigues
wagner {dot} caixeta {at} gmail
