### PR TITLE
Allow for negative tape lengths.

### DIFF
--- a/example/amanda.conf.in
+++ b/example/amanda.conf.in
@@ -259,6 +259,12 @@ define tapetype global {
     part_cache_type none
 }
 
+define tapetype DISK {
+    global
+    comment "File System"
+    length -1 mbytes           # Reserve 1 mbyte
+}
+
 define tapetype QIC-60 {
     global
     comment "Archive Viper"

--- a/man/xml-source/amanda.conf.5.xml
+++ b/man/xml-source/amanda.conf.5.xml
@@ -2570,6 +2570,9 @@ Once the backups start, Amanda will continue to write to a tape until it gets an
 regardless of what value is entered for <amkeyword>length</amkeyword>
 (but see <manref name="amanda-devices" vol="7" /> for exceptions).
  </para>
+<para>When using file: for <amkeyword>tapedev</amkeywork> or chg-disk: for
+<amkeyword>tpchanger</amkeyword>, you can specify a negative value to represent
+how much less than the full size of the target filesystem to use.</para>
   </listitem>
   </varlistentry>
 


### PR DESCRIPTION
Allow for negative tape lengths to indicate how much less than the size
of the targer filesystem to use for the backups.  This allows for the
use of different size disks/filesystems when running amanda.
