### PR TITLE
Use a binned histogram by dump size to compute incremental estimates.

### DIFF
--- a/server-src/amadmin.c
+++ b/server-src/amadmin.c
@@ -52,6 +52,8 @@ int main(int argc, char **argv);
 void usage(void);
 static void estimate(int argc, char **argv);
 static void estimate_one(disk_t *dp);
+static void perfhist(int argc, char **argv);
+static void perfhist_one(disk_t *dp);
 void call_amadmin_perl(int argc, char **argv);
 void info(int argc, char **argv);
 void info_one(disk_t *dp);
@@ -146,6 +148,8 @@ static const struct {
 	T_(" [<hostname> [<disks>]* ]* # Export curinfo database to stdout.") },
     { "import", import_db,
 	T_("\t\t\t\t # Import curinfo database from stdin.") },
+    { "perfhist", perfhist,
+	T_(" [<hostname> [<disks>]* ]*\t# Output compression rate histogram") },
 };
 #define NCMDS G_N_ELEMENTS(cmdtab)
 
@@ -482,6 +486,60 @@ estimate(
     }
 }
 
+
+/* ----------------------------------------------- */
+
+static void
+perfhist_one(
+    disk_t *	dp)
+{
+    char   *hostname = dp->host->hostname;
+    char   *diskname = dp->name;
+    char   *qhost = quote_string(hostname);
+    char   *qdisk = quote_string(diskname);
+    info_t  info;
+    double   *comp_avgs;
+    int     level, nhist, i;
+
+    get_info(hostname, diskname, &info);
+
+    for(level=0;level<=1;level++) {
+	setup_perf_hist(&info, level);
+        comp_avgs = (level==0) ? info.comp_avgs_full : info.comp_avgs_incr;
+        nhist = (level==0) ? info.nhist_full : info.nhist_incr;
+
+	if(nhist) {
+	    printf("%s %s %d", qhost, qdisk, level);
+	    for(i=0;i<64;i++) {
+		if(comp_avgs[i] > 0.0) printf(" %d(%f)",i,comp_avgs[i]);
+	    }
+	    printf("\n");
+	} else {
+	    printf("%s %s %d no history\n", qhost, qdisk, level);
+	}
+    }
+
+    amfree(qhost);
+    amfree(qdisk);
+}
+
+
+static void
+perfhist(
+    int		argc,
+    char **	argv)
+{
+    GList  *dlist;
+    disk_t *dp;
+
+    if(argc >= 4)
+	diskloop(argc, argv, "perfhist", perfhist_one);
+    else
+	for(dlist = diskq.head; dlist != NULL; dlist = dlist->next) {
+	    dp = dlist->data;
+	    perfhist_one(dp);
+	}
+}
 
 /* ----------------------------------------------- */
 

--- a/server-src/infofile.h
+++ b/server-src/infofile.h
@@ -79,6 +79,10 @@ typedef struct info_s {
 #	define FORCE_LEVEL_1	8	/* force level 1 at next run */
     perf_t  full;
     perf_t  incr;
+    double comp_avgs_full[64];
+    double comp_avgs_incr[64];
+    int nhist_full;
+    int nhist_incr;
     stats_t inf[DUMP_LEVELS];
     int last_level, consecutive_runs;
     history_t history[NB_HISTORY+1];
@@ -91,6 +95,8 @@ void close_infofile(void);
 char *get_dumpdate(info_t *info, int level);
 char *get_based_on_timestamp(info_t *info, int lev);
 double perf_average(double *array, double def);
+void setup_perf_hist(info_t * info, int level);
+double perf_hist(info_t *info, int level, off_t size, double def);
 int get_info(char *hostname, char *diskname, info_t *info);
 int put_info(char *hostname, char *diskname, info_t *info);
 int del_info(char *hostname, char *diskname);

--- a/server-src/planner.c
+++ b/server-src/planner.c
@@ -1418,8 +1418,8 @@ est_csize(
         return;
     }
 
-    if (one_est->level == 0) ratio = ep->fullcomp;
-    else ratio = ep->incrcomp;
+    if (one_est->level == 0) ratio = perf_average(ep->info->full.comp, ep->fullcomp);
+    else ratio = perf_hist(ep->info, one_est->level, size, ep->incrcomp);
 
     /*
      * make sure over-inflated compression ratios don't throw off the


### PR DESCRIPTION
Speaking of better estimates:

The compression rate on incremental backups tends to vary heavily based
on the size of the incremental.  This method computes the compression
rate much better by only basing the average on similar sizes from the
past.
