### PR TITLE
Application and script abstract classes

### DIFF
--- a/application-src/Makefile.am
+++ b/application-src/Makefile.am
@@ -20,8 +20,16 @@ AM_LDFLAGS = $(AMANDA_STATIC_LDFLAGS) $(AS_NEEDED_FLAGS)
 applicationexec_SCRIPTS_SHELL = script-fail
 
 applicationexec_SCRIPTS_PERL = script-email \
+	     am389bak \
+	     amgrowingfile \
+	     amgrowingzip \
+	     amlibvirtfsfreeze \
 	     amlog-script \
+	     amlvmsnapshot \
+	     amooraw \
+	     amopaquetree \
 	     ampgsql \
+	     amsvnmakehotcopy \
 	     amzfs-sendrecv \
 	     amzfs-snapshot \
 	     amrandom \

--- a/application-src/am389bak.pl
+++ b/application-src/am389bak.pl
@@ -1,0 +1,87 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Script::Am389Bak;
+
+use base 'Amanda::Script::Abstract';
+
+use File::Spec;
+use File::Path qw(make_path remove_tree);
+use IO::File;
+
+sub new {
+    my ( $class, $execute_where, $refopthash ) = @_;
+    my $self = $class->SUPER::new($execute_where, $refopthash);
+
+    $self->{'db2bakexecutable'} = $self->{'options'}->{'db2bakexecutable'};
+    if ( !defined $self->{'db2bakexecutable'} ) {
+	$self->{'db2bakexecutable'} = 'db2bak';
+    }
+
+    $self->{'instance'} = $self->{'options'}->{'instance'};
+    if ( !defined $self->{'instance'} ) {
+        $self->print_to_server_and_die(
+	    'script requires instance property');
+    }
+
+    return $self;
+}
+
+sub declare_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_options($refopthash, $refoptspecs);
+    push @$refoptspecs, ( 'db2bakexecutable=s', 'instance=s' );
+}
+
+sub command_pre_dle_estimate {
+    my ( $self ) = @_;
+
+    my $repo = $self->{'instance'};
+    my $dst = $self->{'options'}->{'device'};
+
+    make_path($dst);
+    remove_tree($dst, {keep_root => 1});
+
+    my $rslt = system {$self->{'db2bakexecutable'}} (
+        'db2bak', $dst, '-qZ', $repo );
+}
+
+package main;
+
+Amanda::Script::Am389Bak->run();

--- a/application-src/amgrowingfile.pl
+++ b/application-src/amgrowingfile.pl
@@ -1,0 +1,202 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Application::AmGrowingFile;
+
+use base 'Amanda::Application::Abstract';
+
+use Data::Dumper;
+use File::Spec;
+use File::Path qw(make_path);
+
+sub supports_host { my ( $class ) = @_; return 1; }
+sub supports_disk { my ( $class ) = @_; return 1; }
+sub supports_index_line { my ( $class ) = @_; return 1; }
+sub supports_message_line { my ( $class ) = @_; return 1; }
+sub supports_record { my ( $class ) = @_; return 1; }
+sub supports_client_estimate { my ( $class ) = @_; return 1; }
+sub supports_multi_estimate { my ( $class ) = @_; return 1; }
+
+sub max_level { my ( $self ) = @_; return 9; }
+
+sub new {
+    my ( $class, $refopthash ) = @_;
+    my $self = $class->SUPER::new($refopthash);
+    $self->{'localstate'} =
+        $self->read_local_state(['level=i', 'byteoffset=s', 'bytes=s']);
+    return $self;
+}
+
+sub declare_restore_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_restore_options($refopthash, $refoptspecs);
+    push @$refoptspecs, ( 'filename=s' );
+}
+
+sub inner_estimate {
+    my ( $self, $level ) = @_;
+    my $fn = $self->{'options'}->{'device'};
+    my $sz = Math::BigInt->new(-s $fn); # XXX precision issues may lurk here
+    return $sz if 0 == $level;
+
+    my $mxl = $self->{'localstate'}->{'maxlevel'};
+    if ( $level > $mxl ) {
+        $self->print_to_server("Requested estimate level $level > $mxl",
+			       $Amanda::Script_App::ERROR);
+
+        return Math::BigInt->bone('-');
+    }
+    my $lowerstate = $self->{'localstate'}->{$level - 1};
+    my $loweroffset = Math::BigInt->new($lowerstate->{'byteoffset'});
+    my $lowersize = Math::BigInt->new($lowerstate->{'bytes'});
+    return $sz->bsub($loweroffset)->bsub($lowersize);
+}
+
+sub inner_backup {
+    # XXX assert level==0 if no --record
+    my ( $self, $fdout ) = @_;
+    my $fn = $self->{'options'}->{'device'};
+    my $level = $self->{'options'}->{'level'};
+    my $fdin = POSIX::open($fn, &POSIX::O_RDONLY);
+
+    if (!defined $fdin) {
+	$self->print_to_server_and_die("Can't open '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+
+    my $start;
+    if ( 0 == $level ) {
+        $start = Math::BigInt->bzero();
+    } else {
+        # XXX verify prior size and digest here
+        my $lowerstate = $self->{'localstate'}->{$level - 1};
+	# XXX don't be stupid if lowerstate isn't there
+        my $loweroffset = Math::BigInt->new($lowerstate->{'byteoffset'});
+        my $lowersize = Math::BigInt->new($lowerstate->{'bytes'});
+	$start = $loweroffset->copy()->badd($lowersize);
+	my $istart = $start->numify();
+	if ( ($istart - 1) == $istart or $istart == ($istart + 1) ) {
+	    $self->print_to_server_and_die(
+	        "Precision loss for file offset: $fn",
+		$Amanda::Script_App::ERROR);
+	}
+	POSIX::lseek($fdin, $istart, &POSIX::SEEK_SET);
+
+	# sendbackup: HEADER, documented in the Application API/Operations wiki
+	# page, wasn't ever implemented, according to Jean-Louis. An option that
+	# becomes available in 3.3.8 is 'sendbackup: state' and retrieved with
+	# --recover-dump-state-file. The state file is kept on the server, not
+	# clear how /it/ is backed up. May not be available if recovering only
+	# from the tape.
+	#
+	# print {$self->{mesgout}} "sendbackup: HEADER startoffset=$start\n";
+	#
+	# Without doing this, can just /assume/ that the file is currently as
+	# the lower-level restore left it, and append to the end. Not ideal,
+	# but other incremental strategies also perform restores without
+	# rigorous verification of the state they are restoring onto, so when
+	# in Rome....
+    }
+    my $size = $self->shovel($fdin, $fdout);
+
+    POSIX::close($fdin);
+    $self->emit_index_entry('/');
+
+    if ( $self->{'options'}->{'record'} ) {
+        $self->update_local_state($self->{'localstate'}, $level, {
+            'byteoffset' => $start->bstr(), 'bytes' => $size->bstr() });
+        $self->write_local_state($self->{'localstate'});
+    }
+
+    return $size;
+}
+
+sub inner_restore {
+    my $self = shift;
+    my $fdin = shift;
+    my $dsf = shift;
+    my $level = $self->{'options'}->{'level'};
+
+    if ( 1 != scalar(@_) or $_[0] ne '.' ) {
+        $self->print_to_server_and_die(
+	    "Only a single restore target (.) supported",
+	    $Amanda::Script_App::ERROR);
+    }
+
+    my $fn = $self->{'options'}->{'filename'};
+    $fn = 'amgrowingfile-restored' if !defined $fn;
+
+    if ( File::Spec->file_name_is_absolute($fn) ) {
+        $fn = File::Spec->abs2rel($fn, File::Spec->rootdir());
+    }
+
+    my ( $volume, $directories, $file ) = File::Spec->splitpath($fn);
+    make_path(File::Spec->catpath($volume, $directories, ''));
+
+    # Where to begin writing if applying a level > 0 (incremental) dump?
+    # In a cautious world, save the starting offset at dump time, and verify
+    # at restore time that that's where the file ends. That could require either
+    # saving the offset in the dump stream somehow, or using the server-side
+    # state file that appears in 3.3.8 (which still might not be available in a
+    # restoration from only the tape). Short of that, just blindly open in
+    # append mode and write the increment. After all, does an incremental tar
+    # restore actually verify the current directory tree is exactly as the prior
+    # dump level left it? No, it just relies on restoration being done carefully
+    # and in sequence.
+    my $oflags = &POSIX::O_RDWR;
+    if ( $level > 0 ) {
+        $oflags |= &POSIX::O_APPEND;
+    } else {
+        $oflags |= ( &POSIX::O_CREAT | &POSIX::O_TRUNC );
+    }
+
+    my $fdout = POSIX::open($fn, $oflags, 0600);
+    if (!defined $fdout) {
+	$self->print_to_server_and_die("Can't open '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+
+    $self->shovel($fdin, $fdout);
+    POSIX::close($fdout);
+    POSIX::close($fdin);
+}
+
+package main;
+
+Amanda::Application::AmGrowingFile->run();

--- a/application-src/amgrowingzip.pl
+++ b/application-src/amgrowingzip.pl
@@ -1,0 +1,288 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Application::AmGrowingZip;
+
+use base 'Amanda::Application::Abstract';
+
+use Data::Dumper;
+use Fcntl qw(:flock);
+use File::Spec;
+use File::Path qw(make_path);
+use IO::File;
+
+my $usable;
+eval {
+    require Archive::Zip;
+    $usable = 1;
+} or do {
+    $usable = 0;
+};
+
+sub supports_host { my ( $class ) = @_; return 1; }
+sub supports_disk { my ( $class ) = @_; return 1; }
+sub supports_index_line { my ( $class ) = @_; return 1; }
+sub supports_message_line { my ( $class ) = @_; return 1; }
+sub supports_record { my ( $class ) = @_; return 1; }
+sub supports_client_estimate { my ( $class ) = @_; return 1; }
+sub supports_multi_estimate { my ( $class ) = @_; return 1; }
+
+sub max_level { my ( $self ) = @_; return 9; }
+
+sub new {
+    my ( $class, $refopthash ) = @_;
+    my $self = $class->SUPER::new($refopthash);
+    $self->{'localstate'} =
+        $self->read_local_state(
+		['level=i', 'length=s', 'centraldiroffset=s']);
+    return $self;
+}
+
+sub declare_common_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_common_options($refopthash, $refoptspecs);
+    push @$refoptspecs, ( 'flock=s' );
+    $refopthash->{'flock'} = $class->boolean_property_setter($refopthash);
+}
+
+sub declare_restore_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_restore_options($refopthash, $refoptspecs);
+    push @$refoptspecs, ( 'filename=s' );
+}
+
+sub command_selfcheck {
+    my ( $self ) = @_;
+    if ( $usable ) {
+        $self->SUPER::command_selfcheck();
+    } else {
+        $self->print_to_server("$self->{name} Archive::Zip is not installed",
+                               $Amanda::Script_App::ERROR);
+    }
+}
+
+sub inner_estimate {
+    my ( $self, $level ) = @_;
+    my $fn = $self->{'options'}->{'device'};
+    my $sz = Math::BigInt->new(-s $fn); # XXX precision issues may lurk here
+    return $sz if 0 == $level;
+
+    my $mxl = $self->{'localstate'}->{'maxlevel'};
+    if ( $level > $mxl ) {
+        $self->print_to_server("Requested estimate level $level > $mxl",
+			       $Amanda::Script_App::ERROR);
+
+        return Math::BigInt->bone('-');
+    }
+    my $lowerstate = $self->{'localstate'}->{$level - 1};
+    my $lowerlength = Math::BigInt->new($lowerstate->{'length'});
+    my $lowercdo = Math::BigInt->new($lowerstate->{'centraldiroffset'});
+    return Math::BigInt->bzero() if 0 == $sz->bcmp($lowerlength);
+    return $sz->bsub($lowercdo);
+}
+
+sub inner_backup {
+    # XXX assert level==0 if no --record
+    my ( $self, $fdout ) = @_;
+    my $fn = $self->{'options'}->{'device'};
+    my $level = $self->{'options'}->{'level'};
+    my $flock = $self->{'options'}->{'flock'};
+    my $fdin = POSIX::open($fn, &POSIX::O_RDONLY);
+
+    if (!defined $fdin) {
+	$self->print_to_server_and_die("Can't open '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+
+    my $ioh = IO::File->new();
+    $ioh->fdopen($fdin, 'r');
+    my $az = Archive::Zip->new();
+
+    if ( $flock and not flock($ioh, LOCK_SH) ) {
+        $self->print_to_server_and_die("Can't lock '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+    $az->readFromFileHandle($ioh);
+    my $cdo = # XXX precision issues could lurk here
+        Math::BigInt->new($az->centralDirectoryOffsetWRTStartingDiskNumber());
+
+    my $start;
+    my $currentlength = Math::BigInt->new(-s $ioh); # XXX precision issues here?
+    if ( 0 == $level ) {
+        $start = Math::BigInt->bzero();
+    } else {
+        # ENHANCEMENT? could save a prior size and digest, and verify here
+        my $lowerstate = $self->{'localstate'}->{$level - 1};
+	# XXX don't be stupid if lowerstate isn't there
+        my $lowerlength = Math::BigInt->new($lowerstate->{'length'});
+        my $lowercdo = Math::BigInt->new($lowerstate->{'centraldiroffset'});
+	if ( 0 == $currentlength->bcmp($lowerlength) ) {
+	    # Length is unchanged -> nothing has changed (the zip file is
+	    # assumed never to change except by appending).
+	    $start = $currentlength; # In other words, dump nothing.
+	}
+	else {
+	    $start = $lowercdo; # Dump from lowercdo to current length.
+	}
+
+	# sendbackup: HEADER, documented in the Application API/Operations wiki
+	# page, wasn't ever implemented, according to Jean-Louis. An option that
+	# becomes available in 3.3.8 is 'sendbackup: state' and retrieved with
+	# --recover-dump-state-file. The state file is kept on the server, not
+	# clear how /it/ is backed up. May not be available if recovering only
+	# from the tape.
+	#
+	# print {$self->{mesgout}} "sendbackup: HEADER startoffset=$start\n";
+	#
+	# Without doing this, can just /assume/ that the file is currently as
+	# the lower-level restore left it, and append to the end. Not ideal,
+	# but other incremental strategies also perform restores without
+	# rigorous verification of the state they are restoring onto, so when
+	# in Rome....
+    }
+
+    my $istart = $start->numify();
+    if ( ($istart - 1) == $istart or $istart == ($istart + 1) ) {
+        $self->print_to_server_and_die(
+            "Precision loss for file offset: $fn",
+            $Amanda::Script_App::ERROR);
+    }
+    POSIX::lseek($fdin, $istart, &POSIX::SEEK_SET);
+
+    my $size = $self->shovel($fdin, $fdout);
+    if ( $flock and not flock($ioh, LOCK_UN) ) {
+        $self->print_to_server_and_die("Can't unlock '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+
+    POSIX::close($fdin);
+    $self->emit_index_entry('/');
+
+    if ( $self->{'options'}->{'record'} ) {
+        $self->update_local_state($self->{'localstate'}, $level, {
+            'length' => $currentlength->bstr(),
+            'centraldiroffset' => $cdo->bstr() });
+        $self->write_local_state($self->{'localstate'});
+    }
+
+    return $size;
+}
+
+sub inner_restore {
+    my $self = shift;
+    my $fdin = shift;
+    my $dsf = shift;
+    my $level = $self->{'options'}->{'level'};
+    #
+    # There is no point honoring flock during restore. It would be madness
+    # to try to restore a sequence of increments while writes from other
+    # sources could intervene. Restoration must always be done into a secluded
+    # directory/path, only moving the fully restored file back to where other
+    # processes may write it.
+
+    if ( 1 != scalar(@_) or $_[0] ne '.' ) {
+        $self->print_to_server_and_die(
+	    "Only a single restore target (.) supported",
+	    $Amanda::Script_App::ERROR);
+    }
+
+    my $fn = $self->{'options'}->{'filename'};
+    $fn = 'amgrowingzip-restored' if !defined $fn;
+
+    if ( File::Spec->file_name_is_absolute($fn) ) {
+        $fn = File::Spec->abs2rel($fn, File::Spec->rootdir());
+    }
+
+    my ( $volume, $directories, $file ) = File::Spec->splitpath($fn);
+    make_path(File::Spec->catpath($volume, $directories, ''));
+
+    # Where to begin writing if applying a level > 0 (incremental) dump? In a
+    # cautious world, save the starting offset at dump time, and verify at
+    # restore time that that's where the central directory starts. That could
+    # require either saving the offset in the dump stream somehow, or using the
+    # server-side state file that appears in 3.3.8 (which still might not be
+    # available in a restoration from only the tape). Short of that, just
+    # blindly open in rdwr mode, seek to its central directory offset, and write
+    # the increment. After all, does an incremental tar restore actually verify
+    # the current directory tree is exactly as the prior dump level left it? No,
+    # it just relies on restoration being done carefully and in sequence.
+    my $oflags = &POSIX::O_RDWR;
+    if ( $level == 0 ) {
+        $oflags |= ( &POSIX::O_CREAT | &POSIX::O_TRUNC );
+    }
+
+    my $fdout = POSIX::open($fn, $oflags, 0600);
+    if (!defined $fdout) {
+	$self->print_to_server_and_die("Can't open '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+
+    my $ioh = IO::File->new(); # don't let out of scope before shovel()
+    if ( $level > 0 ) {
+        $ioh->fdopen($fdout, 'r');
+        my $az = Archive::Zip->new();
+        $az->readFromFileHandle($ioh);
+        my $cdo = Math::BigInt->new( # XXX precision issues could lurk here
+	    $az->centralDirectoryOffsetWRTStartingDiskNumber());
+	my $ioff = $cdo->numify();
+	if ( ( $ioff - 1 ) == $ioff or ( $ioff == $ioff + 1 ) ) {
+	    $self->print_to_server_and_die(
+	        "Precision loss for file offset: $fn",
+		$Amanda::Script_App::ERROR);
+	}
+	POSIX::lseek($fdout, $ioff, &POSIX::SEEK_SET);
+	# We are now positioned at the beginning of the "central" directory
+	# found at the end of the zip file, and the file is open for RDWR
+	# without TRUNC. If the increment was dumped when more content had been
+	# appended to the zip, there will be a stream to write here that is
+	# strictly longer than the old directory, so no need to truncate. If
+	# the increment was dumped when nothing had changed, there is a zero
+	# length stream to shovel here, leaving the file untruncated and intact.
+	# (Amanda seems to discard increments that dump zero bytes, anyway, so
+	# this case normally should not even arise.)
+    }
+
+    $self->shovel($fdin, $fdout);
+    POSIX::close($fdout);
+    POSIX::close($fdin);
+}
+
+package main;
+
+Amanda::Application::AmGrowingZip->run();

--- a/application-src/amlibvirtfsfreeze.pl
+++ b/application-src/amlibvirtfsfreeze.pl
@@ -1,0 +1,117 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Script::AmLibvirtFSFreeze;
+
+use base 'Amanda::Script::Abstract';
+
+use File::Spec;
+use IO::File;
+
+sub new {
+    my ( $class, $execute_where, $refopthash ) = @_;
+    my $self = $class->SUPER::new($execute_where, $refopthash);
+
+    $self->{'virshexecutable'} = $self->{'options'}->{'virshexecutable'};
+
+    $self->{'freezeorthaw'} = $self->{'options'}->{'freezeorthaw'};
+    if ( !defined $self->{'freezeorthaw'}
+      or $self->{'freezeorthaw'} !~ /^(?:freeze|thaw)$/ ) {
+        $self->print_to_server_and_die(
+	    'script requires freezeorthaw property to be freeze or thaw');
+    }
+
+    $self->{'domain'} = $self->{'options'}->{'domain'};
+    if ( !defined $self->{'domain'} ) {
+        $self->print_to_server_and_die(
+	    'script requires domain property');
+    }
+
+    $self->{'mountpoint'} = $self->{'options'}->{'mountpoint'};
+
+    return $self;
+}
+
+sub declare_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_options($refopthash, $refoptspecs);
+    push @$refoptspecs, (
+       'virshexecutable=s',
+       'freezeorthaw=s',
+       'domain=s',
+       'mountpoint=s@'
+       );
+    # properties that have defaults and are not mandatory to receive with the
+    # request can be initialized here as an alternative to checking for !defined
+    # and applying the defaults in new().
+    $refopthash->{'virshexecutable'} = 'virsh';
+    $refopthash->{     'mountpoint'} = [];
+}
+
+sub command_pre_dle_estimate {
+    my ( $self ) = @_;
+
+    my $fort = $self->{'freezeorthaw'};
+    my $domain = $self->{'domain'};
+    my @args;
+
+    if ( 'freeze' eq $self->{'freezeorthaw'} ) {
+        my @mountpoints = @{$self->{'mountpoint'}};
+        @args = ( 'virsh', 'domfsfreeze', $domain, @mountpoints );
+    } else {
+        @args = ( 'virsh', 'domfsthaw', $domain );
+    }
+
+    my $rslt = system {$self->{'virshexecutable'}} (@args);
+}
+
+# In an ideal world, just run at PRE-DLE-ESTIMATE to make one snapshot,
+# estimate from it, dump from it, then free it in POST-DLE-BACKUP. But on
+# a host with little free space for a snapshot and possibly a long planning wait
+# between the estimate and the dump, it may be better to support being called
+# at PRE-DLE-BACKUP also, in case a second snapshot is to be made then.
+
+sub command_pre_dle_backup {
+    my ( $self ) = @_;
+    $self->command_pre_dle_estimate();
+}
+
+package main;
+
+Amanda::Script::AmLibvirtFSFreeze->run();

--- a/application-src/amlvmsnapshot.pl
+++ b/application-src/amlvmsnapshot.pl
@@ -1,0 +1,193 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Script::AmLvmSnapshot;
+
+use base 'Amanda::Script::Abstract';
+
+use File::Spec;
+use File::Path qw(make_path remove_tree);
+use IO::File;
+
+sub new {
+    my ( $class, $execute_where, $refopthash ) = @_;
+    my $self = $class->SUPER::new($execute_where, $refopthash);
+
+    $self->{'lvmexecutable'} = $self->{'options'}->{'lvmexecutable'};
+    $self->{'mountexecutable'} = $self->{'options'}->{'mountexecutable'};
+    $self->{'umountexecutable'} = $self->{'options'}->{'umountexecutable'};
+
+    $self->{'volumegroup'} = $self->{'options'}->{'volumegroup'};
+    if ( !defined $self->{'volumegroup'} ) {
+        $self->print_to_server_and_die(
+	    'script requires volumegroup property');
+    }
+
+    $self->{'logicalvolume'} = $self->{'options'}->{'logicalvolume'};
+    if ( !defined $self->{'logicalvolume'} ) {
+        $self->print_to_server_and_die(
+	    'script requires logicalvolume property');
+    }
+
+    $self->{'snapshotname'} = $self->{'options'}->{'snapshotname'};
+    if ( !defined $self->{'snapshotname'} ) {
+        $self->print_to_server_and_die(
+	    'script requires snapshotname property');
+    }
+
+    $self->{'extents'} = $self->{'options'}->{'extents'};
+    if ( !defined $self->{'extents'} ) {
+        $self->print_to_server_and_die(
+	    'script requires extents property');
+    }
+
+    $self->{'mountopts'} = $self->{'options'}->{'mountopts'};
+
+    return $self;
+}
+
+sub declare_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_options($refopthash, $refoptspecs);
+    push @$refoptspecs, (
+       'lvmexecutable=s',
+       'mountexecutable=s',
+       'umountexecutable=s',
+       'volumegroup=s',
+       'logicalvolume=s',
+       'snapshotname=s',
+       'extents=s',
+       'mountopts=s@'
+       );
+    # properties that have defaults and are not mandatory to receive with the
+    # request can be initialized here as an alternative to checking for !defined
+    # and applying the defaults in new().
+    $refopthash->{   'lvmexecutable'} = 'lvm';
+    $refopthash->{ 'mountexecutable'} = 'mount';
+    $refopthash->{'umountexecutable'} = 'umount';
+    $refopthash->{       'mountopts'} = [];
+}
+
+sub command_pre_dle_estimate {
+    my ( $self ) = @_;
+
+    my $vg = $self->{'volumegroup'};
+    my $lv = $self->{'logicalvolume'};
+    my $sn = $self->{'snapshotname'};
+    my $extents = $self->{'extents'};
+
+    my $dst = $self->{'options'}->{'device'};
+
+    make_path($dst);
+
+    # NOTE: lvm mumbles a couple lines on stdout, where they'll be mistaken
+    # for script output, eventually confusing the Amanda reader of the stream,
+    # which will think the sendsize timed out. Simply redirecting stdout to
+    # stderr for the lvm invocation fixes that. For now, instead of being done
+    # here in Perl, it's being done in the setuid wrapper executable supplied
+    # as 'lvmexecutable'. For clarity and generality it would be nicer here.
+    # Even nicer would be to handle it all transparently in the superclass.
+
+    my $rslt = system {$self->{'lvmexecutable'}} (
+        'lvm', 'lvcreate',
+	'--snapshot', $vg.'/'.$lv,
+	'--extents', $extents,
+	'--name', $sn,
+	'--permission', 'r'
+    );
+
+    if ( 0 != $rslt ) {
+        $self->print_to_server_and_die(
+	    'lvmcreate returned nonzero status '.$rslt);
+    }
+
+    $rslt = system {$self->{'mountexecutable'}} (
+        'mount',
+	'-o', join(',', ('ro', @{$self->{'mountopts'}})),
+	'/dev/disk/by-id/dm-name-'.$vg.'-'.$sn,
+	$dst
+    );
+}
+
+sub command_post_dle_backup {
+    my ( $self ) = @_;
+
+    my $vg = $self->{'volumegroup'};
+    my $sn = $self->{'snapshotname'};
+
+    my $dst = $self->{'options'}->{'device'};
+
+    my $rslt = system {$self->{'umountexecutable'}} (
+        'umount', $dst
+    );
+
+    if ( 0 != $rslt ) {
+        $self->print_to_server_and_die(
+	    'umount returned nonzero status '.$rslt);
+    }
+
+    # TODO: before destroying, run lvs and capture Data% value - see how
+    # close we came to using up allocated --extents capacity in the time it
+    # took to do the backup.
+    $rslt = system {$self->{'lvmexecutable'}} (
+        'lvm',
+	'lvremove', '--force', $vg.'/'.$sn
+    );
+}
+
+# In an ideal world, just run at PRE-DLE-ESTIMATE to make one snapshot,
+# estimate from it, dump from it, then free it in POST-DLE-BACKUP. But on
+# a host with little free space for a snapshot and possibly a long planning wait
+# between the estimate and the dump, it may be better to support being called
+# at POST-DLE-ESTIMATE (to free one snapshot, same as POST-DLE-BACKUP) and
+# at PRE-DLE-BACKUP (to make another, same as PRE-DLE-ESTIMATE).
+
+sub command_post_dle_estimate {
+    my ( $self ) = @_;
+    $self->command_post_dle_backup();
+}
+
+sub command_pre_dle_backup {
+    my ( $self ) = @_;
+    $self->command_pre_dle_estimate();
+}
+
+package main;
+
+Amanda::Script::AmLvmSnapshot->run();

--- a/application-src/amooraw.pl
+++ b/application-src/amooraw.pl
@@ -1,0 +1,116 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Application::Amooraw;
+
+use base 'Amanda::Application::Abstract';
+
+use Data::Dumper;
+use File::Spec;
+use File::Path qw(make_path);
+
+sub supports_message_line { my ( $class ) = @_; return 1; }
+sub supports_index_line { my ( $class ) = @_; return 1; }
+sub supports_client_estimate { my ( $class ) = @_; return 1; }
+
+sub declare_restore_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_restore_options($refopthash, $refoptspecs);
+    push @$refoptspecs, ( 'filename=s' );
+}
+
+sub inner_estimate {
+    my ( $self, $level ) = @_;
+    my $fn = $self->{'options'}->{'device'};
+    return Math::BigInt->new(-s $fn); # XXX precision issues may lurk here
+}
+
+sub inner_backup {
+    my ( $self, $fdout ) = @_;
+    my $fn = $self->{'options'}->{'device'};
+    my $fdin = POSIX::open($fn, &POSIX::O_RDONLY);
+
+    if (!defined $fdin) {
+	$self->print_to_server_and_die("Can't open '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+
+    my $size = $self->shovel($fdin, $fdout);
+
+    POSIX::close($fdin);
+    $self->emit_index_entry('/');
+
+    return $size;
+}
+
+sub inner_restore {
+    my $self = shift;
+    my $fdin = shift;
+    my $dsf = shift;
+
+    if ( 1 != scalar(@_) or $_[0] ne '.' ) {
+        $self->print_to_server_and_die(
+	    "Only a single restore target (.) supported",
+	    $Amanda::Script_App::ERROR);
+    }
+
+    my $fn = $self->{'options'}->{'filename'};
+    $fn = 'amooraw-restored' if !defined $fn;
+
+    if ( File::Spec->file_name_is_absolute($fn) ) {
+        $fn = File::Spec->abs2rel($fn, File::Spec->rootdir());
+    }
+
+    my ( $volume, $directories, $file ) = File::Spec->splitpath($fn);
+    make_path(File::Spec->catpath($volume, $directories, ''));
+
+    my $fdout = POSIX::open($fn, &POSIX::O_CREAT | &POSIX::O_RDWR, 0600);
+    if (!defined $fdout) {
+	$self->print_to_server_and_die("Can't open '$fn': $!",
+				       $Amanda::Script_App::ERROR);
+    }
+
+    $self->shovel($fdin, $fdout);
+    POSIX::close($fdout);
+    POSIX::close($fdin);
+}
+
+package main;
+
+Amanda::Application::Amooraw->run();

--- a/application-src/amopaquetree.pl
+++ b/application-src/amopaquetree.pl
@@ -1,0 +1,325 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Application::AmOpaqueTree::DirWrap;
+#
+# A tiny class that wraps a directory name as an object with a dirname()
+# method that returns it ... so it can be treated the same way as a result
+# from File::Temp->newdir(), which behaves that way.
+#
+
+sub new {
+    my ( $class, $dirname ) = @_;
+    my $self = { 'dn' => $dirname };
+    return bless($self, $class);
+}
+
+sub dirname {
+    my ( $self ) = @_;
+    return $self->{'dn'};
+}
+
+package Amanda::Application::AmOpaqueTree;
+#
+# The main attraction.
+#
+
+use base 'Amanda::Application::Abstract';
+
+use Data::Dumper;
+use Fcntl;
+use File::Spec;
+use File::Temp;
+use File::Path qw(make_path remove_tree);
+use IO::File;
+use IPC::Open3;
+
+sub supports_host { my ( $class ) = @_; return 1; }
+sub supports_disk { my ( $class ) = @_; return 1; }
+sub supports_index_line { my ( $class ) = @_; return 1; }
+sub supports_message_line { my ( $class ) = @_; return 1; }
+sub supports_record { my ( $class ) = @_; return 1; }
+sub supports_client_estimate { my ( $class ) = @_; return 1; }
+sub supports_multi_estimate { my ( $class ) = @_; return 1; }
+
+sub max_level { my ( $self ) = @_; return 9; }
+
+sub rsync_is_unusable {
+    my ( $self ) = @_;
+    my ( $wtr, $rdr );
+    my $pid = eval {
+        open3($wtr, $rdr, undef, $self->{'rsyncexecutable'}, '--version');
+    };
+    return $@ if $@;
+    close $wtr;
+    my $output = do { local $/; <$rdr> };
+    close $rdr;
+    waitpid $pid, 0;
+    return $output if $?;
+    unless ( $output =~ qr/(?:^\s|,\s)hardlinks(?:,\s|$)/m ) {
+        return $self->{'rsyncexecutable'} . ' lacks hardlink support.';
+    }
+    unless ( $output =~ qr/(?:^\s|,\s)batchfiles(?:,\s|$)/m ) {
+        return $self->{'rsyncexecutable'} . ' lacks batchfile support.';
+    }
+    return 0; # hooray, it isn't unusable.
+}
+
+sub new {
+    my ( $class, $refopthash ) = @_;
+    my $self = $class->SUPER::new($refopthash);
+
+    $self->{'rsyncexecutable'} = $self->{'options'}->{'rsyncexecutable'};
+    if ( !defined $self->{'rsyncexecutable'} ) {
+	$self->{'rsyncexecutable'} = 'rsync';
+    }
+
+    $self->{'localstatedir'} = $self->{'options'}->{'localstatedir'};
+
+    $self->{'rsyncstatesdir'} = $self->{'options'}->{'rsyncstatesdir'};
+    if ( !defined $self->{'rsyncstatesdir'} ) {
+        my ( $dirpart, $filepart ) = $self->local_state_path();
+	$self->{'rsyncstatesdir'} =
+	    File::Spec->catdir($dirpart, 'rsyncstates');
+    }
+
+    $self->{'rsynctempbatchdir'} = $self->{'options'}->{'rsynctempbatchdir'};
+
+    $self->{'localstate'} =
+        $self->read_local_state(['level=i', 'rsyncstate=s']);
+
+    return $self;
+}
+
+sub declare_common_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_common_options($refopthash, $refoptspecs);
+    push @$refoptspecs,
+        ( 'rsyncexecutable=s', 'rsyncstatesdir=s', 'rsynctempbatchdir=s',
+	  'localstatedir=s' );
+}
+
+sub local_state_path {
+    my ( $self ) = @_;
+    if ( defined $self->{'localstatedir'} ) {
+        return $self->build_state_path($self->{'localstatedir'});
+    }
+    return $self->SUPER::local_state_path();
+}
+
+sub generate_rsync_batch {
+    my ( $self, $basedOn, $yielding ) = @_;
+    my $batch = File::Temp->new(
+        DIR => $self->{'rsynctempbatchdir'},
+	EXLOCK => 0
+    );
+
+    my $rslt = system {$self->{'rsyncexecutable'}} (
+        'rsync',
+	'-rlpt', '--checksum', '--delete-during', '--compress', '--sparse',
+	'--only-write-batch', $batch->filename,
+	File::Spec->catfile($yielding, ''),
+	File::Spec->catfile($basedOn, '')
+    );
+
+    unlink($batch->filename . '.sh');
+
+    return $batch;
+}
+
+sub empty_rsync_state_dir {
+    my ( $self, $transient ) = @_;
+    if ( ! -d $self->{'rsyncstatesdir'} ) {
+        make_path($self->{'rsyncstatesdir'});
+    }
+    return File::Temp->newdir(
+        DIR => $self->{'rsyncstatesdir'}, CLEANUP => $transient);
+}
+
+sub best_link_dest {
+    my ( $self, $level ) = @_;
+
+    my $prior = ( $level > 0 ) ? $level : $self->{'localstate'}->{'maxlevel'};
+    $prior -= 1;
+    my $linkdest;
+    if ( exists $self->{'localstate'}->{$prior} ) {
+        $linkdest = $self->{'localstate'}->{$prior}->{'rsyncstate'};
+    }
+    if ( defined $linkdest ) {
+        $linkdest = Amanda::Application::AmOpaqueTree::DirWrap->new($linkdest);
+    } else {
+        $linkdest = $self->empty_rsync_state_dir(1);
+    }
+    return $linkdest;
+}
+
+sub capture_rsync_state {
+    my ( $self, $srcdir, $dstdir, $linkdestdir ) = @_;
+
+    my $rslt = system {$self->{'rsyncexecutable'}} (
+        'rsync',
+	'-rlp', '--whole-file', '--checksum', '--copy-dirlinks', '--sparse',
+	'--link-dest', $linkdestdir,
+	File::Spec->catfile($srcdir, ''),
+	File::Spec->catfile($dstdir, '')
+    );
+}
+
+sub rsync_ref_for_level {
+    my ( $self, $level ) = @_;
+    my $ref;
+    if ( 0 == $level ) {
+        $ref = $self->empty_rsync_state_dir(1);
+    } else {
+        $ref = $self->{'localstate'}->{$level - 1}->{'rsyncstate'};
+	$ref = Amanda::Application::AmOpaqueTree::DirWrap->new($ref);
+    }
+
+    return $ref;
+}
+
+sub inner_estimate {
+    my ( $self, $level ) = @_;
+    my $mxl = $self->{'localstate'}->{'maxlevel'};
+    if ( $level > $mxl ) {
+        $self->print_to_server("Requested estimate level $level > $mxl",
+			       $Amanda::Script_App::ERROR);
+
+        return Math::BigInt->bone('-');
+    }
+
+    my $dn = $self->{'options'}->{'device'};
+    my $ref = $self->rsync_ref_for_level($level);
+    my $batch = $self->generate_rsync_batch($ref->dirname(), $dn);
+    $batch->seek(0, &Fcntl::SEEK_END);
+    my $sz = Math::BigInt->new($batch->tell()); # XXX precision issues may lurk
+    return $sz;
+    # $batch is removed once out of scope
+}
+
+sub inner_backup {
+    # XXX assert level==0 if no --record
+    my ( $self, $fdout ) = @_;
+    my $dn = $self->{'options'}->{'device'};
+    my $level = $self->{'options'}->{'level'};
+
+    my $dst; # only used in --record case, but needed again further below
+    if ( $self->{'options'}->{'record'} ) {
+        my $bld = $self->best_link_dest($level);
+	$dst = $self->empty_rsync_state_dir(0)->dirname();
+	$self->capture_rsync_state($dn, $dst, $bld->dirname());
+	$dn = $dst;
+    }
+
+    my $ref = $self->rsync_ref_for_level($level);
+    my $batch = $self->generate_rsync_batch($ref->dirname(), $dn);
+    $batch->seek(0, &Fcntl::SEEK_SET);
+    my $fdin = fileno($batch);
+    POSIX::lseek($fdin, 0, &POSIX::SEEK_SET); # probably not needed, but...
+    my $size = $self->shovel($fdin, $fdout);
+
+    $self->emit_index_entry('/');
+
+    if ( $self->{'options'}->{'record'} ) {
+        $self->update_local_state($self->{'localstate'}, $level, {
+            'rsyncstate' => $dst });
+        $self->write_local_state($self->{'localstate'});
+    }
+
+    return $size;
+}
+
+sub inner_restore {
+    my $self = shift;
+    my $fdin = shift;
+    my $dsf = shift;
+    my $level = $self->{'options'}->{'level'};
+
+    if ( 1 != scalar(@_) or $_[0] ne '.' ) {
+        $self->print_to_server_and_die(
+	    "Only a single restore target (.) supported",
+	    $Amanda::Script_App::ERROR);
+    }
+
+    my $dn = File::Spec->curdir();
+
+    if ( 0 == $level ) {
+	remove_tree($dn, {keep_root => 1});
+    }
+
+    my $rslt = system {$self->{'rsyncexecutable'}} (
+        'rsync',
+	'-rlpt', '--checksum', '--delete-during', '--compress', '--sparse',
+	'--read-batch', '-', File::Spec->catfile($dn, '')
+    );
+
+    POSIX::close($fdin);
+}
+
+sub update_local_state {
+    my ( $self, $state, $level, $opthash ) = @_;
+    $self->{'orphanedrsyncstates'} = [];
+    for ( my ($l, $oh); ($l, $oh) = each %$state; ) {
+        next if 'maxlevel' eq $l or (0 + $l) lt $level;
+	push @{$self->{'orphanedrsyncstates'}}, $oh->{'rsyncstate'};
+    }
+    $self->SUPER::update_local_state($state, $level, $opthash);
+}
+
+sub write_local_state {
+    my ( $self, $levhash ) = @_;
+    $self->SUPER::write_local_state($levhash);
+    for my $ors ( @{$self->{'orphanedrsyncstates'}} ) {
+        remove_tree($ors);
+    }
+}
+
+sub command_selfcheck {
+    my ( $self ) = @_;
+    my $why = $self->rsync_is_unusable();
+    if ( $why ) {
+        $self->print_to_server($why, $Amanda::Script_App::ERROR);
+    } else {
+        $self->SUPER::command_selfcheck();
+    }
+}
+
+package main;
+
+Amanda::Application::AmOpaqueTree->run();

--- a/application-src/amsvnmakehotcopy.pl
+++ b/application-src/amsvnmakehotcopy.pl
@@ -1,0 +1,87 @@
+#!@PERL@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+
+package Amanda::Script::AmSvnMakeHotcopy;
+
+use base 'Amanda::Script::Abstract';
+
+use File::Spec;
+use File::Path qw(make_path remove_tree);
+use IO::File;
+
+sub new {
+    my ( $class, $execute_where, $refopthash ) = @_;
+    my $self = $class->SUPER::new($execute_where, $refopthash);
+
+    $self->{'svnadminexecutable'} = $self->{'options'}->{'svnadminexecutable'};
+    if ( !defined $self->{'svnadminexecutable'} ) {
+	$self->{'svnadminexecutable'} = 'svnadmin';
+    }
+
+    $self->{'svnrepository'} = $self->{'options'}->{'svnrepository'};
+    if ( !defined $self->{'svnrepository'} ) {
+        $self->print_to_server_and_die(
+	    'script requires svnrepository property');
+    }
+
+    return $self;
+}
+
+sub declare_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->SUPER::declare_options($refopthash, $refoptspecs);
+    push @$refoptspecs, ( 'svnadminexecutable=s', 'svnrepository=s' );
+}
+
+sub command_pre_dle_estimate {
+    my ( $self ) = @_;
+
+    my $repo = $self->{'svnrepository'};
+    my $dst = $self->{'options'}->{'device'};
+
+    make_path($dst);
+    remove_tree($dst, {keep_root => 1});
+
+    my $rslt = system {$self->{'svnadminexecutable'}} (
+        'svnadmin', 'hotcopy', $repo, $dst );
+}
+
+package main;
+
+Amanda::Script::AmSvnMakeHotcopy->run();

--- a/installcheck/Makefile.am
+++ b/installcheck/Makefile.am
@@ -21,7 +21,11 @@ all_tests += $(common_tests)
 client_tests = \
         noop \
 	ambsdtar \
+	amgrowingfile \
+	amgrowingzip \
 	amgtar \
+	amooraw \
+	amopaquetree \
 	ampgsql \
 	amraw \
 	amstar \

--- a/installcheck/amgrowingfile.pl
+++ b/installcheck/amgrowingfile.pl
@@ -1,0 +1,115 @@
+# Copyright (c) 2009-2012 Zmanda, Inc.  All Rights Reserved.
+# Copyright (c) 2013-2016 Carbonite, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+#
+# Contact information: Carbonite Inc., 756 N Pastoria Ave
+# Sunnyvale, CA 94086, USA, or: http://www.zmanda.com
+
+use Test::More tests => 28;
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+use Installcheck;
+use Amanda::Constants;
+use Amanda::Debug;
+use Amanda::Paths;
+use Amanda::Tests;
+use File::Path;
+use Installcheck::Application;
+use IO::File;
+
+Amanda::Debug::dbopen("installcheck");
+Installcheck::log_test_output();
+
+my $app = Installcheck::Application->new('amgrowingfile');
+
+my $support = $app->support();
+is($support->{'INDEX-LINE'}, 'YES', "supports indexing");
+is($support->{'MESSAGE-LINE'}, 'YES', "supports messages");
+is($support->{'CLIENT-ESTIMATE'}, 'YES', "supports estimates");
+is($support->{'RECORD'}, 'YES', "supports record");
+is($support->{'MULTI-ESTIMATE'}, 'YES', "supports multi-estimates");
+
+my $root_dir = "$Installcheck::TMP/installcheck-amgrowingfile";
+my $back_file = "$root_dir/to_backup";
+my $rest_dir = "$root_dir/restore";
+
+File::Path::mkpath($root_dir);
+File::Path::mkpath($rest_dir);
+Amanda::Tests::write_random_file(0xabcde, 1024*256, $back_file);
+
+my $selfcheck = $app->selfcheck('device' => $back_file, 'level' => 0, 'index' => 'line');
+is($selfcheck->{'exit_status'}, 0, "error status ok");
+ok(!@{$selfcheck->{'errors'}}, "no errors during selfcheck");
+
+my $backup = $app->backup('device' => $back_file, 'level' => 0,
+                          'index' => 'line', 'record' => undef);
+is($backup->{'exit_status'}, 0, "error status ok");
+ok(!@{$backup->{'errors'}}, "no errors during backup")
+    or diag(@{$backup->{'errors'}});
+
+is(length($backup->{'data'}), $backup->{'size'}, "reported and actual size match");
+
+ok(@{$backup->{'index'}}, "index is not empty");
+is_deeply($backup->{'index'}, ["/"], "index is '/'");
+
+open my $bfh, '>>', $back_file;
+print $bfh $backup->{'data'};
+close $bfh;
+
+my $backup1 = $app->backup('device' => $back_file, 'level' => 1,
+                           'index' => 'line');
+is($backup1->{'exit_status'}, 0, "error status ok");
+ok(!@{$backup1->{'errors'}}, "no errors during backup")
+    or diag(@{$backup1->{'errors'}});
+
+is(length($backup1->{'data'}), $backup1->{'size'}, "reported and actual size match");
+
+ok(@{$backup1->{'index'}}, "index is not empty");
+is_deeply($backup1->{'index'}, ["/"], "index is '/'");
+
+my $orig_cur_dir = POSIX::getcwd();
+ok($orig_cur_dir, "got current directory");
+
+ok(chdir($rest_dir), "changed working directory (for restore)");
+
+my $restore = $app->restore('objects' => ['.'],'data' => $backup->{'data'});
+is($restore->{'exit_status'}, 0, "error status ok (default filename)");
+$restore = $app->restore('objects' => ['.'],'data' => $backup1->{'data'},
+                         'level'=> 1);
+is($restore->{'exit_status'}, 0, "error status ok (default filename; increment)");
+
+$app->add_property('filename', 'custom-filename');
+$restore = $app->restore('objects' => ['.'],'data' => $backup->{'data'});
+is($restore->{'exit_status'}, 0, "error status ok (custom filename)");
+$restore = $app->restore('objects' => ['.'],'data' => $backup1->{'data'},
+                            'level'=> 1);
+is($restore->{'exit_status'}, 0, "error status ok (custom filename; increment)");
+
+ok(chdir($orig_cur_dir), "changed working directory (back to original)");
+
+my $restore_file = "$rest_dir/amgrowingfile-restored";
+ok(-f "$restore_file", "amgrowingfile-restored restored");
+is(`cmp $back_file $restore_file`, "", "restore match");
+
+$restore_file = "$rest_dir/custom-filename";
+ok(-f "$restore_file", "custom-filename restored");
+is(`cmp $back_file $restore_file`, "", "restore match");
+
+# cleanup
+#exit(1);
+rmtree($root_dir);

--- a/installcheck/amgrowingzip.pl
+++ b/installcheck/amgrowingzip.pl
@@ -1,0 +1,194 @@
+# Copyright (c) 2009-2012 Zmanda, Inc.  All Rights Reserved.
+# Copyright (c) 2013-2016 Carbonite, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+#
+# Contact information: Carbonite Inc., 756 N Pastoria Ave
+# Sunnyvale, CA 94086, USA, or: http://www.zmanda.com
+
+use Test::More;
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+use Installcheck;
+use Amanda::Constants;
+use Amanda::Debug;
+use Amanda::Paths;
+use Amanda::Tests;
+use Fcntl qw(SEEK_SET);
+use File::Path;
+use Installcheck::Application;
+use IO::File;
+
+eval {
+    require Archive::Zip;
+    plan tests => 31;
+    1;
+} or do {
+    plan skip_all => 'tested only if Archive::Zip is installed';
+};
+
+Amanda::Debug::dbopen("installcheck");
+Installcheck::log_test_output();
+
+my $app = Installcheck::Application->new('amgrowingzip');
+
+my $support = $app->support();
+is($support->{'INDEX-LINE'}, 'YES', "supports indexing");
+is($support->{'MESSAGE-LINE'}, 'YES', "supports messages");
+is($support->{'CLIENT-ESTIMATE'}, 'YES', "supports estimates");
+is($support->{'RECORD'}, 'YES', "supports record");
+is($support->{'MULTI-ESTIMATE'}, 'YES', "supports multi-estimates");
+
+my $root_dir = "$Installcheck::TMP/installcheck-amgrowingzip";
+my $back_file = "$root_dir/to_backup";
+my $rest_dir = "$root_dir/restore";
+
+File::Path::mkpath($root_dir);
+File::Path::mkpath($rest_dir);
+
+# Create a test ZIP archive whose members will consist of random stuff;
+# Amanda::Tests::write_random_file only writes an actual file. So (this
+# is a test, it doesn't have to be pretty) just do that, then slurp in
+# the file contents as $random_stuff; the file will get truncated and
+# overwritten later as the actual ZIP archive.
+
+Amanda::Tests::write_random_file(0xabcde, 1024*256, $back_file);
+
+my $random_stuff;
+{
+    local $/;
+    open my $fh, '<', $back_file;
+    $random_stuff = <$fh>;
+    close $fh;
+}
+
+# Ironically, while Perl's Archive::Zip provides all the functionality needed
+# to do incremental backup of incrementally-growing ZIP files (a function to
+# return the central directory offset is enough), it isn't adequate to actually
+# CREATE incrementally-growing ZIP files (easy as that is in Python with the
+# zipfile module). That makes creating the test case in Perl a bit tricky.
+# Perl does, however, provide enough functionality to do the job backwards:
+# write a two-entry ZIP file, then delete the second entry from the central
+# directory, and rewrite the central directory at the original offset of the
+# second entry in the ZIP file, leaving a one-entry ZIP. By first saving the
+# raw bytes from the second entry offset to the end of the file before
+# truncating, they can be written back later to emulate 'growing' the ZIP by
+# adding the second entry. The things done in the name of testing....
+
+my $zf = Archive::Zip->new();
+my $thing1 = $zf->addString($random_stuff, 'Thing1');
+my $thing2 = $zf->addString($random_stuff, 'Thing2');
+
+open my $bfh, '+>', $back_file;
+$zf->writeToFileHandle($bfh, 1);
+ok($thing2->wasWritten(), "both entries in test zip were written");
+
+# Backspace to the offset where thing2 begins, and save everything from there
+# to the end of the file (including the directory records at the end). The
+# writeLocalHeaderRelativeOffset method is just a getter, doesn't write stuff.
+
+my $thing2offset = $thing2->writeLocalHeaderRelativeOffset();
+seek $bfh, $thing2offset, SEEK_SET;
+my $tail_data;
+{
+    local $/;
+    $tail_data = <$bfh>;
+}
+
+# Remove thing2 from the in-memory directory of entries, then rewrite that
+# directory at the offset where thing2 originally started in the file.
+
+$zf->removeMember($thing2);
+$zf->writeCentralDirectory($bfh, $thing2offset);
+truncate $bfh, (tell $bfh);
+
+# Wasn't that easy? Now it's a one-entry archive suitable for testing
+# backup level 0.
+
+close $bfh;
+
+my $selfcheck = $app->selfcheck('device' => $back_file, 'level' => 0, 'index' => 'line');
+is($selfcheck->{'exit_status'}, 0, "error status ok");
+ok(!@{$selfcheck->{'errors'}}, "no errors during selfcheck");
+
+my $backup = $app->backup('device' => $back_file, 'level' => 0,
+                          'index' => 'line', 'record' => undef);
+is($backup->{'exit_status'}, 0, "error status ok");
+ok(!@{$backup->{'errors'}}, "no errors during backup")
+    or diag(@{$backup->{'errors'}});
+
+my $size_rounded_up = 1024 * int(( length($backup->{'data'}) + 1023 ) / 1024);
+is($size_rounded_up, $backup->{'size'}, "reported and actual size match");
+
+ok(@{$backup->{'index'}}, "index is not empty");
+is_deeply($backup->{'index'}, ["/"], "index is '/'");
+
+# Ok, here it goes, back to a two-entry archive....
+
+open $bfh, '+<', $back_file;
+seek $bfh, $thing2offset, SEEK_SET;
+print $bfh $tail_data;
+close $bfh;
+
+my $backup1 = $app->backup('device' => $back_file, 'level' => 1,
+                           'index' => 'line');
+is($backup1->{'exit_status'}, 0, "error status ok");
+ok(!@{$backup1->{'errors'}}, "no errors during backup")
+    or diag(@{$backup1->{'errors'}});
+
+$size_rounded_up = 1024 * int(( length($backup1->{'data'}) + 1023 ) / 1024);
+is($size_rounded_up, $backup1->{'size'}, "reported and actual size match");
+
+ok(@{$backup1->{'index'}}, "index is not empty");
+is_deeply($backup1->{'index'}, ["/"], "index is '/'");
+
+my $orig_cur_dir = POSIX::getcwd();
+ok($orig_cur_dir, "got current directory");
+
+ok(chdir($rest_dir), "changed working directory (for restore)");
+
+my $restore = $app->restore('objects' => ['.'],'data' => $backup->{'data'});
+is($restore->{'exit_status'}, 0, "error status ok (default filename)");
+$restore = $app->restore('objects' => ['.'],'data' => $backup1->{'data'},
+                         'level'=> 1);
+is($restore->{'exit_status'}, 0, "error status ok (default filename; increment)");
+
+$app->add_property('filename', 'custom-filename');
+$restore = $app->restore('objects' => ['.'],'data' => $backup->{'data'});
+is($restore->{'exit_status'}, 0, "error status ok (custom filename)");
+$restore = $app->restore('objects' => ['.'],'data' => $backup1->{'data'},
+                            'level'=> 1);
+is($restore->{'exit_status'}, 0, "error status ok (custom filename; increment)");
+
+ok(chdir($orig_cur_dir), "changed working directory (back to original)");
+
+my $restore_file = "$rest_dir/amgrowingzip-restored";
+ok(-f "$restore_file", "amgrowingzip-restored restored");
+is(`cmp $back_file $restore_file`, "", "restore match");
+
+$restore_file = "$rest_dir/custom-filename";
+ok(-f "$restore_file", "custom-filename restored");
+is(`cmp $back_file $restore_file`, "", "restore match");
+
+$zf = Archive::Zip->new($restore_file);
+isnt($zf, undef, "restored archive is present and well-formed");
+is_deeply(\[$zf->memberNames()], \['Thing1', 'Thing2'],
+          "contains the right entries");
+
+# cleanup
+#exit(1);
+rmtree($root_dir);

--- a/installcheck/amooraw.pl
+++ b/installcheck/amooraw.pl
@@ -1,0 +1,91 @@
+# Copyright (c) 2009-2012 Zmanda, Inc.  All Rights Reserved.
+# Copyright (c) 2013-2016 Carbonite, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+#
+# Contact information: Carbonite Inc., 756 N Pastoria Ave
+# Sunnyvale, CA 94086, USA, or: http://www.zmanda.com
+
+use Test::More tests => 19;
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+use Installcheck;
+use Amanda::Constants;
+use Amanda::Debug;
+use Amanda::Paths;
+use Amanda::Tests;
+use File::Path;
+use Installcheck::Application;
+use IO::File;
+
+Amanda::Debug::dbopen("installcheck");
+Installcheck::log_test_output();
+
+my $app = Installcheck::Application->new('amooraw');
+
+my $support = $app->support();
+is($support->{'INDEX-LINE'}, 'YES', "supports indexing");
+is($support->{'MESSAGE-LINE'}, 'YES', "supports messages");
+is($support->{'CLIENT-ESTIMATE'}, 'YES', "supports estimates");
+
+my $root_dir = "$Installcheck::TMP/installcheck-amooraw";
+my $back_file = "$root_dir/to_backup";
+my $rest_dir = "$root_dir/restore";
+
+File::Path::mkpath($root_dir);
+File::Path::mkpath($rest_dir);
+Amanda::Tests::write_random_file(0xabcde, 1024*256, $back_file);
+
+my $selfcheck = $app->selfcheck('device' => $back_file, 'level' => 0, 'index' => 'line');
+is($selfcheck->{'exit_status'}, 0, "error status ok");
+ok(!@{$selfcheck->{'errors'}}, "no errors during selfcheck");
+
+my $backup = $app->backup('device' => $back_file, 'level' => 0, 'index' => 'line');
+is($backup->{'exit_status'}, 0, "error status ok");
+ok(!@{$backup->{'errors'}}, "no errors during backup")
+    or diag(@{$backup->{'errors'}});
+
+is(length($backup->{'data'}), $backup->{'size'}, "reported and actual size match");
+
+ok(@{$backup->{'index'}}, "index is not empty");
+is_deeply($backup->{'index'}, ["/"], "index is '/'");
+
+my $orig_cur_dir = POSIX::getcwd();
+ok($orig_cur_dir, "got current directory");
+
+ok(chdir($rest_dir), "changed working directory (for restore)");
+
+my $restore = $app->restore('objects' => ['.'],'data' => $backup->{'data'});
+is($restore->{'exit_status'}, 0, "error status ok (default filename)");
+
+$app->add_property('filename', 'custom-filename');
+$restore = $app->restore('objects' => ['.'],'data' => $backup->{'data'});
+is($restore->{'exit_status'}, 0, "error status ok (custom filename)");
+
+ok(chdir($orig_cur_dir), "changed working directory (back to original)");
+
+my $restore_file = "$rest_dir/amooraw-restored";
+ok(-f "$restore_file", "amooraw-restored restored");
+is(`cmp $back_file $restore_file`, "", "restore match");
+
+$restore_file = "$rest_dir/custom-filename";
+ok(-f "$restore_file", "custom-filename restored");
+is(`cmp $back_file $restore_file`, "", "restore match");
+
+# cleanup
+#exit(1);
+rmtree($root_dir);

--- a/installcheck/amopaquetree.pl
+++ b/installcheck/amopaquetree.pl
@@ -1,0 +1,150 @@
+# Copyright (c) 2009-2012 Zmanda, Inc.  All Rights Reserved.
+# Copyright (c) 2013-2016 Carbonite, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+#
+# Contact information: Carbonite Inc., 756 N Pastoria Ave
+# Sunnyvale, CA 94086, USA, or: http://www.zmanda.com
+
+use Test::More;
+
+use lib '@amperldir@';
+use strict;
+use warnings;
+use Installcheck;
+use Amanda::Constants;
+use Amanda::Debug;
+use Amanda::Paths;
+use Amanda::Tests;
+use Amanda::Util;
+use Fcntl qw(SEEK_SET);
+use File::Path;
+use Installcheck::Application;
+use IO::File;
+use IPC::Open3;
+
+Amanda::Debug::dbopen("installcheck");
+Installcheck::log_test_output();
+
+sub rsync_is_unusable {
+    my ( $self ) = @_;
+    my ( $wtr, $rdr );
+    my $pid = eval { open3($wtr, $rdr, undef, 'rsync', '--version') };
+    return $@ if $@;
+    close $wtr;
+    my $output = do { local $/; <$rdr> };
+    close $rdr;
+    waitpid $pid, 0;
+    return $output if $?;
+    unless ( $output =~ qr/(?:^\s|,\s)hardlinks(?:,\s|$)/m ) {
+        return 'rsync lacks hardlink support.';
+    }
+    unless ( $output =~ qr/(?:^\s|,\s)batchfiles(?:,\s|$)/m ) {
+        return 'rsync lacks batchfile support.';
+    }
+    return 0; # hooray, it isn't unusable.
+}
+
+my $why = rsync_is_unusable();
+unless ( $why ) {
+    plan tests => 26;
+} else {
+    plan skip_all => $why;
+}
+
+my $app = Installcheck::Application->new('amopaquetree');
+
+my $support = $app->support();
+is($support->{'INDEX-LINE'}, 'YES', "supports indexing");
+is($support->{'MESSAGE-LINE'}, 'YES', "supports messages");
+is($support->{'CLIENT-ESTIMATE'}, 'YES', "supports estimates");
+is($support->{'RECORD'}, 'YES', "supports record");
+is($support->{'MULTI-ESTIMATE'}, 'YES', "supports multi-estimates");
+
+my $root_dir = "$Installcheck::TMP/installcheck-amopaquetree";
+my $back_dir = "$root_dir/to_backup";
+my $rest_dir = "$root_dir/restore";
+my $file1 = "file1";
+my $file2 = "file2";
+
+File::Path::mkpath($back_dir);
+File::Path::mkpath($rest_dir);
+
+Amanda::Tests::write_random_file(0xabcde, 1024*256, "$back_dir/$file1");
+Amanda::Tests::write_random_file(0xfedcb, 1024*256, "$back_dir/$file2");
+
+my $selfcheck = $app->selfcheck('device' => $back_dir, 'level' => 0, 'index' => 'line');
+is($selfcheck->{'exit_status'}, 0, "error status ok");
+ok(!@{$selfcheck->{'errors'}}, "no errors during selfcheck")
+    or diag(@{$selfcheck->{'errors'}});
+
+my $backup = $app->backup('device' => $back_dir, 'level' => 0,
+                          'index' => 'line', 'record' => undef);
+is($backup->{'exit_status'}, 0, "error status ok");
+ok(!@{$backup->{'errors'}}, "no errors during backup")
+    or diag(@{$backup->{'errors'}});
+
+my $size_rounded_up = 1024 * int(( length($backup->{'data'}) + 1023 ) / 1024);
+is($size_rounded_up, $backup->{'size'}, "reported and actual size match");
+
+ok(@{$backup->{'index'}}, "index is not empty");
+is_deeply($backup->{'index'}, ["/"], "index is '/'");
+
+# make a small modification somewhere inside file2 (just grab some of the
+# random data from some spot in file1, to some other spot in file2)....
+open my $fh1,  '<', $back_dir.'/'.$file1;
+open my $fh2, '+<', $back_dir.'/'.$file2;
+seek $fh1, 1024*23, SEEK_SET;
+seek $fh2, 1024*57, SEEK_SET;
+my $buf = Amanda::Util::full_read(fileno($fh1), 1024*32);
+close $fh1;
+Amanda::Util::full_write(fileno($fh2), $buf, 1024*32);
+close $fh2;
+
+my $backup1 = $app->backup('device' => $back_dir, 'level' => 1,
+                           'index' => 'line');
+is($backup1->{'exit_status'}, 0, "error status ok");
+ok(!@{$backup1->{'errors'}}, "no errors during backup")
+    or diag(@{$backup1->{'errors'}});
+
+$size_rounded_up = 1024 * int(( length($backup1->{'data'}) + 1023 ) / 1024);
+is($size_rounded_up, $backup1->{'size'}, "reported and actual size match");
+
+ok(@{$backup1->{'index'}}, "index is not empty");
+is_deeply($backup1->{'index'}, ["/"], "index is '/'");
+
+my $orig_cur_dir = POSIX::getcwd();
+ok($orig_cur_dir, "got current directory");
+
+ok(chdir($rest_dir), "changed working directory (for restore)");
+
+my $restore = $app->restore('objects' => ['.'],'data' => $backup->{'data'});
+is($restore->{'exit_status'}, 0, "error status ok");
+$restore = $app->restore('objects' => ['.'],'data' => $backup1->{'data'},
+                         'level'=> 1);
+is($restore->{'exit_status'}, 0, "error status ok (increment)");
+ok(chdir($orig_cur_dir), "changed working directory (back to original)");
+
+my $restore_file = "$rest_dir/$file1";
+ok(-f "$restore_file", "file1 restored");
+is(`cmp "$back_dir/$file1" $restore_file`, "", "file1 match");
+
+$restore_file = "$rest_dir/$file2";
+ok(-f "$restore_file", "file2 restored");
+is(`cmp "$back_dir/$file2" $restore_file`, "", "file2 match");
+
+# cleanup
+#exit(1);
+rmtree($root_dir);

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -23,15 +23,23 @@ COMMON_MAN_PAGES =  amanda.8 \
 
 CLIENT_MAN_PAGES = \
     amanda-applications.7 \
+    am389bak.8 \
     ambackup.8 \
     ambsdtar.8 \
     amdump_client.8 \
+    amgrowingfile.8 \
+    amgrowingzip.8 \
     amgtar.8 \
+    amlibvirtfsfreeze.8 \
+    amlvmsnapshot.8 \
+    amooraw.8 \
+    amopaquetree.8 \
     ampgsql.8 \
     amraw.8 \
     amsamba.8 \
     amstar.8 \
     amsuntar.8 \
+    amsvnmakehotcopy.8 \
     amzfs-snapshot.8 \
     amzfs-sendrecv.8
 

--- a/man/xml-source/am389bak.8.xml
+++ b/man/xml-source/am389bak.8.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM 'global.entities'>
+  %global_entities;
+]>
+
+<refentry id='am389bak.8'>
+
+<refmeta>
+<refentrytitle>am389bak</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>am389bak</refname>
+<refpurpose>Amanda script for online copy of a 389 Directory Server</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>am389bak is an Amanda script implementing the Script API.
+It should not be run by users directly.  It uses the
+<command>db2bak</command> command to make a consistent copy
+of a 389 Directory Server instance.</para>
+
+<para>The name of the directory server instance (the <emphasis>foo</emphasis>
+part, if <literal>slapd-foo</literal> is the directory where its files
+are found) is given in the INSTANCE property, and the consistent copy will be
+made into the directory named by <emphasis remap='B'>diskdevice</emphasis> in
+the disklist (DLE). This is the directory where the estimate and backup
+application (<manref name='amopaquetree' vol='8'/> could be appropriate) will
+expect to find the data for backup.</para>
+
+<para>The copy is made after <emphasis>removing all existing
+content under the directory named as the
+<emphasis remap='B'>diskdevice</emphasis></emphasis>, all of
+which happens during PRE-DLE-ESTIMATE, which must be set to be executed
+on the client:
+<programlisting>
+    execute-on  pre-dle-estimate
+    execute-where client
+</programlisting></para>
+
+<para>The script is run as the amanda user, and must be able to run the
+<command>db2bak</command> command as the user running 389. This can be done
+by setting the DB2BAKEXECUTABLE property not to the path of
+<command>db2bak</command> itself, but to a set-uid
+<emphasis>and set-gid</emphasis> wrapper that obtains the effective user
+<emphasis>and group</emphasis> IDs of the 389 user, copies those to the
+real IDs (<command>db2bak</command> is quite finicky), and finally spawns
+<command>db2bak</command> with the same arguments. The wrapper should
+take all appropriate precautions to avoid being misused, such as checking
+the arguments to verify that they match a backup request of an expected
+389 instance.</para>
+
+<note><para>If the wrapper is made both set-uid and set-gid to the user
+that runs 389, there is no way left (in traditional Unix permissions) to
+leave the wrapper executable by the Amanda user (except by making it
+executable to everyone, which misses the point). However, modern filesystems
+typically support access control lists, so the wrapper can be given an ACL
+with execute permission granted to the Amanda user specifically.</para></note>
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control am389bak's
+functionality.
+See <manref name="amanda-scripts" vol="7"/>
+for information on the Script API, script configuration.</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>DB2BAKEXECUTABLE</term><listitem>
+Path to the <command>db2bak</command> executable, search in $PATH by default.
+In realistic settings, this will point instead to a set-uid and set-gid wrapper
+that (after appropriate checks) will execute <command>db2bak</command> with
+the same arguments.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>INSTANCE</term><listitem>
+Name of the 389 Directory Server instance (the <emphasis>foo</emphasis>
+part, if <literal>slapd-foo</literal> is the directory where its files
+are found) to be backed up.
+</listitem></varlistentry>
+ <!-- ==== -->
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+
+<para>This example defines a script <literal>make389bak</literal>,
+using it with an (assumed defined) <literal>app_amopaquetree</literal>
+application (see <manref name='amopaquetree' vol='8'/>) to do
+incremental backup of the directory data for instance
+<literal>myinst</literal>.</para>
+
+<para>In <manref name='amanda.conf' vol='5'/>:
+<programlisting>
+ define script "make389bak" {
+   plugin "am389bak"
+   execute-where client
+   execute-on pre-dle-estimate
+   property "db2bakexecutable" "/path/to/db2bak-wrapper"
+ }
+</programlisting></para>
+
+<para>In <manref name='disklist' vol='5'/>:
+<programlisting>
+ ldaphost myinst /tmp/389bak {
+   global
+   estimate client
+   program "APPLICATION"
+   application "app_amopaquetree"
+   script {
+     "make389bak"
+     property "instance" "myinst"
+   }
+ } 1 enet100
+</programlisting></para>
+</refsect1>
+
+<refsect1><title>BUGS</title>
+<para>This script does not (yet) make any effort to detect failures.</para>
+
+<para>The <command>db2bak</command> utility does so many inconvenient things
+that there is extra cleanup work needed when it is done. As that work also needs
+to be done as the 389 user, it is most easily done in the set-uid wrapper,
+which therefore cannot simply execute <command>db2bak</command> after some
+setup, but must execute it in a subprocess, wait for it, and then do further
+work.
+<itemizedlist>
+<listitem>
+<para>If the directory into which the backup is to be made already exists,
+<command>db2bak</command> first renames it to the same name with
+<literal>.bak</literal> tacked on. There is no documented option to turn off
+that behavior. Harmless enough, unless <emphasis>that</emphasis> directory
+also already exists, in which case <command>db2bak</command> simply fails.
+So the wrapper may need to remove any such directory so that situation is
+avoided.</para>
+</listitem>
+<listitem>
+<para>When <command>db2bak</command> creates files in the destination directory,
+it sets their modes explicitly to disallow any group access, which complicates
+making the files readable to the Amanda user after the script completes and
+the backup application needs to read them. A POSIX default ACL on the
+destination directory will not suffice, because even though the files inherit
+it, the later explicit denial of group permission masks it off. So the wrapper
+may need to change permissions or alter ACLs on the files after
+<command>db2bak</command> completes.</para>
+</listitem>
+</itemizedlist></para>
+
+<para>The number of tasks that have to be done under an ID other than Amanda's
+makes a case for adding some general, secure, easily configured way for Amanda
+applications and scripts to run specific operations with privilege, but that
+remains future work.</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-client.conf" vol="5"/>,
+<manref name="amanda-scripts" vol="7"/>
+</seealso>
+
+
+</refentry>

--- a/man/xml-source/amanda-applications.7.xml
+++ b/man/xml-source/amanda-applications.7.xml
@@ -37,8 +37,27 @@
 
 <itemizedlist>
 <listitem>
+<manref name="amgrowingfile" vol="8"/>,
+- incremental backup of a single large file known to be only appended.
+</listitem>
+<listitem>
+<manref name="amgrowingzip" vol="8"/>,
+- incremental backup of a single large ZIP known to only have new members
+appended.
+</listitem>
+<listitem>
 <manref name="amgtar" vol="8"/>,
 - use GNU Tar to backup and restore data.
+</listitem>
+<listitem>
+<manref name="amooraw" vol="8"/>,
+- use open and read to read the data. Like <manref name="amraw" vol="8"/>,
+but in simpler, OO style.
+</listitem>
+<listitem>
+<manref name="amopaquetree" vol="8"/>,
+- use rsync to make increments only from differing regions, not whole changed
+files.
 </listitem>
 <listitem>
 <manref name="ampgsql" vol="8"/>,

--- a/man/xml-source/amanda-applications.7.xml
+++ b/man/xml-source/amanda-applications.7.xml
@@ -83,10 +83,6 @@ files.
 <manref name="amzfs-sendrecv" vol="8"/>,
 - use zfs to create a snapshot and use 'zfs send' to generate the backup.
 </listitem>
-<listitem>
-<manref name="amzfs-snapshot" vol="8"/>,
-- use zfs to create a snapshot and for use with other applications (e.g. amgtar)
-</listitem>
 </itemizedlist>
 
 </refsect1>

--- a/man/xml-source/amanda-scripts.7.xml
+++ b/man/xml-source/amanda-scripts.7.xml
@@ -41,6 +41,22 @@ see http://wiki.zmanda.com/index.php/Script_API.</para>
 
 <itemizedlist>
 <listitem>
+<manref name="am389bak" vol="8"/>,
+- generate consistent point-in-time copy of a 389 Directory Server instance.
+</listitem>
+<listitem>
+<manref name="amlibvirtfsfreeze" vol="8"/>,
+- freeze/thaw guest VM filesystems so image files are not dirty on host backup.
+</listitem>
+<listitem>
+<manref name="amlvmsnapshot" vol="8"/>,
+- create/destroy and mount/unmount LVM snapshot.
+</listitem>
+<listitem>
+<manref name="amsvnmakehotcopy" vol="8"/>,
+- generate consistent point-in-time copy of a Subversion repository.
+</listitem>
+<listitem>
 <manref name="amzfs-snapshot" vol="8"/>,
 - create/destroy zfs snapshot.
 </listitem>

--- a/man/xml-source/amgrowingfile.8.xml
+++ b/man/xml-source/amgrowingfile.8.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM '../entities/global.entities'>
+  %global_entities;
+]>
+
+<refentry id='amgrowingfile.8'>
+
+<refmeta>
+<refentrytitle>amgrowingfile</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>amgrowingfile</refname>
+<refpurpose>Amanda Application for backup of single append-only file</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>Amgrowingfile is an Amanda Application API script.  It should not be run
+by users directly.  It can backup and restore a single file that is known
+to change only by appending.</para>
+
+<para>Such a file may represent audit or logging data, a stream of data
+being acquired from instrumentation, etc. Backup levels are supported, where
+a backup level greater than zero simply consists of all data written to the
+file beyond its length in the prior-level backup.</para>
+
+<note><para>For correctness, this strategy requires that the file be known
+to grow only at the end. On some operating systems (see the
+<command>chattr</command> command in Linux, for example), an
+<emphasis>append-only</emphasis> flag can be set on the file to enforce this.
+If the file is ever rewritten from the start (such as in log rotation), the
+next <command>amgrowingfile</command> backup must be forced to level 0.
+</para></note>
+
+<para>The <emphasis remap='B'>diskdevice</emphasis> in the disklist (DLE)
+is the filename <command>amgrowingfile</command> will read. When restoring,
+the FILENAME property (which can be set with the
+<emphasis remap='B'>setproperty</emphasis> command in
+<manref name="amrecover" vol="8"/>) will be used, or, if it is not set,
+<filename>amgrowingfile-restored</filename> in the current directory.
+In other words, <command>amgrowingfile</command> will not default to
+restoring data directly to the original filename, but the FILENAME property
+can be set to do so, if desired.
+</para>
+
+<para>When restoring, the file named with the FILENAME property (or
+<filename>amgrowingfile-restored</filename>) is truncated and rewritten
+in place if it exists, or created with mode 0600 if it does not.</para>
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control amgrowingfile's
+functionality.
+See <manref name="amanda-applications" vol="7"/>
+for information on application properties and how they are configured.</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>FILENAME</term><listitem>
+Used only for restore command, can be a device name or file, the data will
+be restored to it.
+</listitem></varlistentry>
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+<para>
+<programlisting>
+  define application-tool app_amgrowingfile {
+    plugin "amgrowingfile"
+  }
+</programlisting>
+A dumptype using this application might look like:
+<programlisting>
+  define dumptype amgrowingfile {
+    global
+    program "APPLICATION"
+    application "app_amgrowingfile"
+  }
+</programlisting>
+Note that the <emphasis>program</emphasis> parameter must be set to
+<emphasis>"APPLICATION"</emphasis> to use the <emphasis>application</emphasis>
+parameter.
+</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-applications" vol="7"/>
+<manref name="amrecover" vol="8"/>
+</seealso>
+
+</refentry>

--- a/man/xml-source/amgrowingzip.8.xml
+++ b/man/xml-source/amgrowingzip.8.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM '../entities/global.entities'>
+  %global_entities;
+]>
+
+<refentry id='amgrowingzip.8'>
+
+<refmeta>
+<refentrytitle>amgrowingzip</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>amgrowingzip</refname>
+<refpurpose>Amanda Application for backup of append-only ZIP archive</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>Amgrowingzip is an Amanda Application API script.  It should not be run
+by users directly.  It can backup and restore a single file that is
+a ZIP archive known to change only by appending members.</para>
+
+<para>Such a file may be used to collect many small files that are created
+over time, such as data acquired from instruments, write-ahead logs of some
+databases, etc. Where many small files in a directory could use disk blocks
+inefficiently, appending them, as they are generated, to a growing ZIP archive
+can achieve efficient storage along with the ability to extract individual
+files from the ZIP as needed.</para>
+
+<para>Amgrowingzip itself only deals with the ZIP archive as a unit.
+When restoring, the entire archive will be restored. Any extraction of
+individual members from the archive can then be done with ordinary ZIP
+tools. The growing ZIP file can be large, and amgrowingzip supports backup
+levels.</para>
+
+<note><para>For correctness, this application requires that the ZIP archive
+be known to grow only by new members being appended to it. This is analogous to
+an append-only operation at the file level, but not the same, so it cannot
+be enforced by typical <emphasis>append-only</emphasis> flags offered by
+the operating system. The structure of a ZIP archive consists of members of
+the archive (typically compressed), followed by a directory structure
+at the end. Appending a member involves seeking to the end of the file,
+backspacing to the start of the directory structure, and overwriting with the
+new member(s) followed by the new directory structure. For amgrowingzip,
+a backup level greater than zero is simply everything that must be written
+over the file starting at the directory structure offset in the prior-level 
+backup.</para>
+
+<para>Any time the ZIP archive is rebuilt rather than simply appended,
+the next <command>amgrowingzip</command> backup must be forced to level 0.
+Not all ZIP-related tools truly append a member as described here;
+some perform any modification of the archive by rebuilding it from scratch.
+To be usable with amgrowingzip, whatever process adds members to the archive
+must be known to truly append them. The <package>zipfile</package> module in
+Python is suitable, for example.
+</para></note>
+
+<note><para>If it is possible for the process that appends members to be
+active while <command>amgrowingzip</command> is taking a backup, the FLOCK
+property should be set, and the appending process should also be coded to
+hold an advisory exclusive lock on the archive file during each modification.
+Otherwise, a failure or unusable backup could result from trying to locate
+the archive's directory while a write is in progress.
+</para></note>
+
+<para>The <emphasis remap='B'>diskdevice</emphasis> in the disklist (DLE)
+names the ZIP archive <command>amgrowingzip</command> will read. When restoring,
+the FILENAME property (which can be set with the
+<emphasis remap='B'>setproperty</emphasis> command in
+<manref name="amrecover" vol="8"/>) will be used, or, if it is not set,
+<filename>amgrowingzip-restored</filename> in the current directory.
+In other words, <command>amgrowingzip</command> will not default to
+restoring data directly to the original filename, but the FILENAME property
+can be set to do so, if desired.
+</para>
+
+<para>When restoring, the file named with the FILENAME property (or
+<filename>amgrowingzip-restored</filename>) is truncated and rewritten
+in place if it exists, or created with mode 0600 if it does not.</para>
+
+<para>No locking is used while restoring, regardless of the FLOCK property.
+There is no sense in allowing any writes to the file being restored before
+the last increment needed has been applied to it. The best approach is to
+restore under a temporary name and, only after restoration, move the file
+to the expected place.</para>
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control amgrowingfile's
+functionality.
+See <manref name="amanda-applications" vol="7"/>
+for information on application properties and how they are configured.
+For the recognized <amkeyword>true</amkeyword>/<amkeyword>false</amkeyword>
+values for a boolean property, see <manref name="amanda.conf" vol="5"/>.
+</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>FILENAME</term><listitem>
+Used only for restore command, can be a device name or file, the data will
+be restored to it.
+</listitem></varlistentry>
+
+ <!-- ==== -->
+ <varlistentry><term>FLOCK</term><listitem>
+Set to a <amkeyword>true</amkeyword> value to require an advisory shared lock
+before backing up the file, in case the process that appends members to it
+could be simultaneously active. The appending process must also be coded to take
+an advisory exclusive lock while writing. If this property is given a
+<amkeyword>false</amkeyword> value, no locking is used.
+</listitem></varlistentry>
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+<para>
+<programlisting>
+  define application-tool app_amgrowingzip {
+    plugin "amgrowingzip"
+  }
+</programlisting>
+A dumptype using this application might look like:
+<programlisting>
+  define dumptype amgrowingzip {
+    global
+    program "APPLICATION"
+    application "app_amgrowingzip"
+  }
+</programlisting>
+Note that the <emphasis>program</emphasis> parameter must be set to
+<emphasis>"APPLICATION"</emphasis> to use the <emphasis>application</emphasis>
+parameter.
+</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-applications" vol="7"/>
+<manref name="amrecover" vol="8"/>
+</seealso>
+
+</refentry>

--- a/man/xml-source/amlibvirtfsfreeze.8.xml
+++ b/man/xml-source/amlibvirtfsfreeze.8.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM 'global.entities'>
+  %global_entities;
+]>
+
+<refentry id='amlibvirtfsfreeze.8'>
+
+<refmeta>
+<refentrytitle>amlibvirtfsfreeze</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>amlibvirtfsfreeze</refname>
+<refpurpose>Amanda script to freeze/thaw filesystems in VMs</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>amlibvirtfsfreeze is an Amanda script implementing the Script API.
+It should not be run by users directly.  On a machine that hosts
+virtual machines, it uses <package>libvirt</package> to instruct
+a virtual machine to freeze one or more filesystems, and then to thaw
+them after their image files on the host have been backed up.</para>
+
+<para>Freeze and thaw support in libvirt requires that a "guest agent"
+(for example, <manref name="qemu-ga" vol="8"/> for a Linux guest) be installed
+in the guest OS.</para>
+
+<para>When a filesystem is frozen, any buffered changes are forced to storage
+so the image can be backed up while consistent at the filesystem level.
+Activity in the guest that modifies the filesystem may block until the
+filesystem is thawed, so this technique is best combined with a script (such as
+<manref name="amlvmsnapshot" vol="8"/>) to snapshot the host filesystem,
+so the VM guest filesystems need only be frozen long enough to create
+the snapshot on the host.</para>
+
+<para>While a frozen filesystem will not be 'dirty' at the filesystem level,
+freezing alone does not ensure that any files in that filesystem represent
+consistent states of running applications. A guest agent may provide the
+option to run a freeze-hook script in the guest OS just before freezing and
+after thawing, and such a script can take application-specific actions to
+ensure important applications have reached a consistent state and forced it
+to storage as well. More on freeze hooks will be found in the documentation
+for the guest agent being used.</para>
+
+<para>The guest virtual machine ("domain" in libvirt parlance) is specified
+by name in the DOMAIN property, and the MOUNTPOINT property (which can be
+multivalued) specifies which of that domain's filesystems to act on.
+The FREEZEORTHAW property specifies the action.
+</para>
+
+<para>For a thaw action, no MOUNTPOINT is specified, and all filesystems
+frozen in the guest domain are thawed. For a freeze action, MOUNTPOINT may
+need to be omitted if the virtualization software or guest OS are too old
+to support per-filesystem freezing, and in that case, every filesystem mounted
+on the guest is frozen.</para>
+
+<para>This script can be run in PRE-DLE-ESTIMATE, in the case where one
+snapshot will be made before estimating and removed after backup. If limited
+free space in the volume group forces a small snapshot size, or changes to the
+origin filesystem accumulate quickly, or the Amanda installation in total has
+a long delay in planning/dumping between the estimate and backup phases, it is
+possible to execute this script twice, on PRE-DLE-ESTIMATE and PRE-DLE-BACKUP,
+in conjunction with a snapshot script that removes the snapshot used for
+estimating and creates another one for backup. In that case, it would also
+be possible to run this script only for PRE-DLE-BACKUP, as the estimate phase
+can get the size of the image file accurately enough without needing it
+frozen.</para>
+
+<para>The phase (or both phases) must be set to be executed on the client:
+<programlisting>
+    execute-on  pre-dle-estimate
+    #execute-on  pre-dle-estimate, pre-dle-backup
+    execute-where client
+</programlisting></para>
+
+<para>The script is run as the amanda user, and must be able to run the
+necessary <command>virsh</command> command. One approach is to set the
+VIRSHEXECUTABLE property not to the actual path of the command, but to
+a set-uid wrapper that takes the same arguments, checks that they represent
+allowed operations, domains, and filesystems, and then executes the actual
+command with the same arguments.</para>
+
+<note><para>A set-uid wrapper obtains its owner's <emphasis>effective</emphasis>
+ID, but may need to set the <emphasis>real</emphasis> ID to match it before
+the <command>virsh</command> command will permit the operations.</para></note>
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control amlibvirtfsfreeze's
+functionality.
+See <manref name="amanda-scripts" vol="7"/>
+for information on the Script API, script configuration.</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>DOMAIN</term><listitem>
+The name of the libvirt domain, or guest VM, whose filesystems should be
+frozen or thawed.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>FREEZEORTHAW</term><listitem>
+One of the values <literal>freeze</literal> or <literal>thaw</literal>.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>MOUNTPOINT</term><listitem>
+Filesystems in the named domain to be frozen, identified by their mountpoints.
+This property can have multiple values. It is ignored in a
+<literal>thaw</literal> operation; all frozen filesystems will be thawed.
+For some old versions of virtualization infrastructure, the guest agent, or
+guest OS, it must not be used for <literal>freeze</literal> either, in which
+case all mounted filesystems will be frozen.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>VIRSHEXECUTABLE</term><listitem>
+Path to the <command>virsh</command> executable, search in $PATH by default.
+If necessary for authorization, this can be set
+instead to a set-uid wrapper that (after appropriate checks) will
+execute <command>virsh</command> with the same arguments.
+</listitem></varlistentry>
+ <!-- ==== -->
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+
+<para>This example sets up two script definitions,
+<literal>domfsfreeze</literal> and <literal>domfsthaw</literal>, both based on
+this plugin, and a DLE that uses them, along with
+<manref name="amlvmsnapshot" vol="8"/> and an assumed
+<literal>remote-gtar</literal> dumptype, to freeze the root filesystems of
+several guest VMs running on a host, then snapshot the host's filesystem
+(containing the consistent, frozen image files of the guests), thaw the guest
+filesystems, and finally back up the host from the snapshot.</para>
+
+<para>Note the use of the ORDER option in script definitions. The default
+(applied to the <literal>lvmsnapshot</literal> script, which leaves it
+unspecified) is 5000. The explicit 3000 in the <literal>domfsfreeze</literal>
+definition and 7000 for <literal>domfsthaw</literal> ensure that,
+when all three scripts are run in a single phase such as PRE-DLE-ESTIMATE,
+the freezes occur first, then the snapshot, then the thaws.</para>
+
+<para>In a realistic application where <command>amandad</command> does not
+run as the superuser, a privileged wrapper may need to be written and named
+in the VIRSHEXECUTABLE property as discussed above.</para>
+
+<para>In <manref name='amanda.conf' vol='5'/>:
+<programlisting>
+ define script domfsfreeze {
+   plugin "amlibvirtfsfreeze"
+   execute-where client
+   execute-on pre-dle-estimate
+   property "freezeorthaw" "freeze"
+   property "virshexecutable" "/path/to/virsh-wrapper"
+   order 3000 # must execute before lvmsnapshot
+ }
+
+ define script domfsthaw {
+   plugin "amlibvirtfsfreeze"
+   execute-where client
+   execute-on pre-dle-estimate
+   property "freezeorthaw" "thaw"
+   property "virshexecutable" "/path/to/virsh-wrapper"
+   order 7000 # must execute after lvmsnapshot
+ }
+
+ define script "lvmsnapshot" {
+   plugin "amlvmsnapshot"
+   execute-where client
+   execute-on pre-dle-estimate, post-dle-backup
+   # ... see amlvmsnapshot.8
+ }
+
+ define dumptype remote-gtar # ...
+</programlisting></para>
+
+<para>And in <manref name='disklist' vol='5'/>:
+<programlisting>
+ example / /tmp/rootsnap {
+   remote-gtar
+   script {
+     "domfsfreeze"
+     property "domain" "vm1"
+     property "mountpoint" "/"
+   }
+   script {
+     "domfsthaw"
+     property "domain" "vm1"
+   }
+   script {
+     "domfsfreeze"
+     property "domain" "vm2"
+     property "mountpoint" "/"
+   }
+   script {
+     "domfsthaw"
+     property "domain" "vm2"
+   }
+   script {
+     "lvmsnapshot"
+     property "volumegroup"   "vg_example"
+     property "logicalvolume" "lv_root"
+     property "snapshotname"  "snap_root"
+     property "extents"       "10%ORIGIN"
+   }
+ } 1 enet100
+</programlisting></para>
+</refsect1>
+
+<refsect1><title>BUGS</title>
+<para>This script does not (yet) make any effort to detect failures, or to
+capture and interpret standard output from the <command>virsh</command>, which
+normally produces some. Uncaptured, such output mixes with Amanda's
+client/server messaging, leading to backup failures. A cheap workaround is to
+include <code>dup2(2,1)</code> in the wrapper that executes
+<command>virsh</command>, so such output goes to standard error and ends up
+in the client <command>amandad</command> log file.</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-client.conf" vol="5"/>,
+<manref name="amanda-scripts" vol="7"/>
+</seealso>
+
+
+</refentry>

--- a/man/xml-source/amlvmsnapshot.8.xml
+++ b/man/xml-source/amlvmsnapshot.8.xml
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM 'global.entities'>
+  %global_entities;
+]>
+
+<refentry id='amlvmsnapshot.8'>
+
+<refmeta>
+<refentrytitle>amlvmsnapshot</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>amlvmsnapshot</refname>
+<refpurpose>Amanda script to make an LVM snapshot</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>amlvmsnapshot is an Amanda script implementing the Script API.
+It should not be run by users directly.  It creates and mounts a
+snapshot of an LVM filesystem in preparation for backup, then unmounts
+and removes it.</para>
+
+<para>The logical volume to be snapshotted is specified with the VOLUMEGROUP
+and LOGICALVOLUME properties, and the SNAPSHOTNAME property will be used to
+give the created snapshot a name. The EXTENTS property must be set to indicate
+the size of the snapshot. The mount point for the snapshot will be the
+directory named by <emphasis remap='B'>diskdevice</emphasis> in the
+disklist (DLE). This is the directory where the estimate and backup application
+will expect to find the data for backup.</para>
+
+<para>A snapshot begins with nearly zero space consumed, but grows (up to
+the specified size) as the origin filesystem accumulates changes made since
+the snapshot. The EXTENTS property must size the snapshot generously enough
+for the volume of changes expected in the origin filesystem during the
+snapshot's lifetime, while fitting in the volume group's available, unused
+space.</para>
+
+<para>This script can be run in PRE-DLE-ESTIMATE and POST-DLE-BACKUP, in which
+case one snapshot will be made and mounted before estimating, and unmounted and
+removed after backup. If limited free space in the volume group forces a small
+snapshot size, or changes to the origin filesystem accumulate quickly, or the
+Amanda installation in total has a long delay in planning/dumping between the
+estimate and backup phases, it may be safer to execute this script four times,
+on PRE-DLE-ESTIMATE, POST-DLE-ESTIMATE, PRE-DLE-BACKUP, and POST-DLE-BACKUP. In
+that case, the snapshot used for estimating is unmounted and removed after that
+phase, and a new snapshot is created later for actual dumping.</para>
+
+<para>The snapshot is made and mounted after <emphasis>removing all existing
+content under the directory named as the
+<emphasis remap='B'>diskdevice</emphasis></emphasis> if it exists, or
+creating it empty if it does not, which happens
+during PRE-DLE-ESTIMATE (and PRE-DLE-BACKUP if also executed then).
+Both (or all four) phases must be set to be executed on the client:
+<programlisting>
+    execute-on  pre-dle-estimate, post-dle-backup
+    #execute-on  pre-dle-estimate, post-dle-estimate, pre-dle-backup, post-dle-backup
+    execute-where client
+</programlisting></para>
+
+<para>The script is run as the amanda user, and must be able to run the
+necessary <command>lvm</command>, <command>mount</command>, and
+<command>umount</command> commands. One approach is to set the
+LVMEXECUTABLE, MOUNTEXECUTABLE, and UMOUNTEXECUTABLE not to the actual
+paths of those commands, but to set-uid wrappers that take the same
+arguments, check that they represent allowed operations and filesystems,
+and then execute the actual commands with the same arguments.</para>
+
+<note><para>A set-uid wrapper obtains its owner's <emphasis>effective</emphasis>
+ID, but may need to set the <emphasis>real</emphasis> ID to match it before
+the <command>lvm</command>, <command>mount</command>, and
+<command>umount</command> commands will permit the operations.</para></note>
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control amlvmsnapshot's
+functionality.
+See <manref name="amanda-scripts" vol="7"/>
+for information on the Script API, script configuration.</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>EXTENTS</term><listitem>
+The size to make the created snapshot. Syntaxes like
+<literal>10%ORIGIN</literal> or <literal>50%FREE</literal>
+are possible; see <manref name='lvcreate' vol='8'/>.
+There must be at least this much unused space available in
+the same volume group as the origin filesystem, and this size
+must be large enough for all the expected modification activity
+for that filesystem during the snapshot's existence.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>LOGICALVOLUME</term><listitem>
+The name of the logical volume that will be the origin of the snapshot.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>LVMEXECUTABLE</term><listitem>
+Path to the <command>lvm</command> executable, search in $PATH by default.
+If necessary for authorization, this can be set
+instead to a set-uid wrapper that (after appropriate checks) will
+execute <command>lvm</command> with the same arguments.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>MOUNTEXECUTABLE</term><listitem>
+Path to the <command>mount</command> executable, search in $PATH by default.
+If necessary for authorization, this can be set
+instead to a set-uid wrapper that (after appropriate checks) will
+execute <command>mount</command> with the same arguments.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>MOUNTOPTS</term><listitem>
+Mount options to be used when mounting the snapshot. Multiple values
+are accepted. If the filesystem is XFS, two mount options are necessary:
+<programlisting>
+    property "mountopts" "nouuid" "norecovery"
+</programlisting>
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>SNAPSHOTNAME</term><listitem>
+The name to be given to the newly-created snapshot.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>UMOUNTEXECUTABLE</term><listitem>
+Path to the <command>umount</command> executable, search in $PATH by default.
+If necessary for authorization, this can be set
+instead to a set-uid wrapper that (after appropriate checks) will
+execute <command>mount</command> with the same arguments.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>VOLUMEGROUP</term><listitem>
+Name of the volume group in which the logical volume to be snapshotted,
+and in which the snapshot will be created.
+</listitem></varlistentry>
+ <!-- ==== -->
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+
+<para>This example defines a script <literal>lvmsnapshot</literal> and a DLE
+that backs up a logical volume <literal>lv_root</literal> in volume group
+<literal>vg_example</literal> (assuming there is already a
+<literal>remote-gtar</literal> dumptype defined. A single snapshot will be
+used for both the estimate and backup phases. While in use, the snapshot
+will be mounted at <filename>/tmp/rootsnap</filename>, which will be
+created empty if absent, or emptied if present.</para>
+
+<para>A dumptype <literal>remote-gtar-root-tinysnap</literal> dumptype is also
+created, setting the same VOLUMEGROUP, LOGICALVOLUME, SNAPSHOTNAME, and
+EXTENTS properties to avoid repeating them in DLEs for several
+identically-configured clients, and also overriding EXECUTE-ON to use
+a shorter-lived, smaller snapshot for each phase,
+in case a client may have insufficient free space in the volume group for
+all of the modification activity during the longer life of a single
+snapshot.</para>
+
+<para>In a realistic application where <command>amandad</command> does not
+run as the superuser, privileged wrappers may need to be written and named
+in the LVMEXECUTABLE, MOUNTEXECUTABLE, and UMOUNTEXECUTABLE properties as
+discussed above.</para>
+
+<para>In <manref name='amanda.conf' vol='5'/>:
+<programlisting>
+ define script "lvmsnapshot" {
+   plugin "amlvmsnapshot"
+   execute-where client
+   execute-on pre-dle-estimate, post-dle-backup
+   property    "lvmexecutable" "/path/to/lvm-wrapper"
+   property  "mountexecutable" "/path/to/mount-wrapper"
+   property "umountexecutable" "/path/to/umount-wrapper"
+ }
+
+ define dumptype remote-gtar-root-tinysnap {
+   remote-gtar
+   script {
+     "lvmsnapshot"
+     property "volumegroup"   "vg_example"
+     property "logicalvolume" "lv_root"
+     property "snapshotname"  "snap_root"
+     property "extents"       "2%ORIGIN"
+     execute-on pre-dle-estimate, post-dle-estimate, pre-dle-backup, post-dle-backup
+   }
+ }
+</programlisting></para>
+
+<para>And in <manref name='disklist' vol='5'/>:
+<programlisting>
+ example / /tmp/rootsnap {
+   remote-gtar
+   script {
+     "lvmsnapshot"
+     property "volumegroup"   "vg_example"
+     property "logicalvolume" "lv_root"
+     property "snapshotname"  "snap_root"
+     property "extents"       "10%ORIGIN"
+   }
+ } 1 enet100
+
+ tiny / /tmp/rootsnap remote-gtar-root-tinysnap -1 enet100
+</programlisting></para>
+</refsect1>
+
+<refsect1><title>BUGS</title>
+<para>This script does not (yet) make any effort to detect failures, or to
+capture and interpret standard output from the <command>lvm</command>, which
+normally produces some. Uncaptured, such output mixes with Amanda's
+client/server messaging, leading to backup failures. A cheap workaround is to
+include <code>dup2(2,1)</code> in the wrapper that executes
+<command>lvm</command>, so such output goes to standard error and ends up
+in the client <command>amandad</command> log file.</para>
+
+<para>Also, this script does not (yet) do anything to prevent
+<command>lvm</command> inheriting file descriptors other than standard
+input/output/error that are used in Amanda's script API. That leads to
+benign warnings from <command>lvm</command> about file descriptor leaks.
+This also has a cheap workaround that can be added to the wrapper, namely
+to define <literal>LVM_SUPPRESS_FD_WARNINGS</literal> in the environment
+before executing <command>lvm</command>.</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-client.conf" vol="5"/>,
+<manref name="amanda-scripts" vol="7"/>
+</seealso>
+
+
+</refentry>

--- a/man/xml-source/amooraw.8.xml
+++ b/man/xml-source/amooraw.8.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM '../entities/global.entities'>
+  %global_entities;
+]>
+
+<refentry id='amooraw.8'>
+
+<refmeta>
+<refentrytitle>amooraw</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>amooraw</refname>
+<refpurpose>Amanda Application open and read data</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>Amooraw is an Amanda Application API script.  It should not be run
+by users directly.  It directly reads and writes data in a single directory
+entry.</para>
+
+<para>Amooraw can backup only one directory entry, it can be a single file,
+a raw device, anything that amanda can open and read.</para>
+
+<para>It is a reimplementation of <manref name="amraw" vol="8"/> illustrating
+the simpler construction of an Amanda application in object-oriented style
+(the oo in amooraw) using
+<classname>Amanda::Application::Abstract</classname>.</para>
+
+<note><para>Where the original <command>amraw</command>, when restoring,
+allows the destination to be specified with the DIRECTORY property,
+<command>amooraw</command> uses a different property, FILENAME, for that
+purpose. Also, if that property is not specified, restoration will create
+a file <filename>amooraw-restored</filename> instead of blithely overwriting
+the original <emphasis remap='B'>diskdevice</emphasis> named in the DLE.
+If that is what's wanted, simply set the FILENAME property to match the
+<emphasis remap='B'>diskdevice</emphasis>.</para></note>
+
+<para>The <emphasis remap='B'>diskdevice</emphasis> in the disklist (DLE)
+must be the filename <command>amooraw</command> is to open and read.</para>
+
+<para>Restore is done in place: an open is done and the data is written to it.
+A file owned by root and permission 0600 is created if the directory entry
+doesn't exist before the restore.</para>
+
+<para>Only full backup is allowed.</para>
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control amooraw's functionality.
+See <manref name="amanda-applications" vol="7"/>
+for information on application properties and how they are configured.</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>FILENAME</term><listitem>
+Used only for restore command, can be a device name or file, the data will
+be restored to it.
+</listitem></varlistentry>
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+<para>
+<programlisting>
+  define application-tool app_amooraw {
+    plugin "amooraw"
+  }
+</programlisting>
+A dumptype using this application might look like:
+<programlisting>
+  define dumptype amooraw {
+    global
+    program "APPLICATION"
+    application "app_amooraw"
+  }
+</programlisting>
+Note that the <emphasis>program</emphasis> parameter must be set to
+<emphasis>"APPLICATION"</emphasis> to use the <emphasis>application</emphasis>
+parameter.
+</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-applications" vol="7"/>
+<manref name="amrecover" vol="8"/>
+</seealso>
+
+</refentry>

--- a/man/xml-source/amopaquetree.8.xml
+++ b/man/xml-source/amopaquetree.8.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM '../entities/global.entities'>
+  %global_entities;
+]>
+
+<refentry id='amopaquetree.8'>
+
+<refmeta>
+<refentrytitle>amopaquetree</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>amopaquetree</refname>
+<refpurpose>Amanda Application for backup of a directory tree opaquely</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>Amopaquetree is an Amanda Application API script.  It should not be run
+by users directly.  It can backup and restore a directory tree opaquely
+(that is, as a whole, with no option to restore just some entries),
+with efficient increments when large files have only small changes.</para>
+
+<para>Most Amanda applications that backup a directory tree allow selective
+restoration of only some files or subtrees. Also, the typical applications
+that support backup levels, such as <command>amgtar</command>, operate at
+the file level: changes, however small, to any file cause the entire file
+to be included in the incremental backup. These properties are suitable for
+many backup needs.</para>
+
+<para>Some applications, such as databases and products that incorporate them,
+may keep files in a directory structure with obscure naming or numbering,
+where an administrator would rarely be expected to identify or restore selected
+files, but simply to restore the tree at a consistent moment. For such
+applications, the individual files can also be large, and modified only in
+small regions, so that backing up entire changed files would be wasteful.</para>
+
+<para><command>Amopaquetree</command> is intended for those cases.
+A directory-list entry (DLE) backed up with amopaquetree can only be
+restored in full, without selective access to subcomponents. Incremental
+backups will identify only changed regions within files, rather than
+backing up entire files when changed, using more storage and computation
+on the client, but saving network bandwidth, holding disk, and tape space.
+</para>
+
+<para>The extra storage required on the client is similar to the size of
+the tree to be backed up. Other Amanda applications supporting incremental
+backup store only a small client-local state, such as a date or a file list,
+for each previous backup level. For <command>amopaquetree</command>, the
+client-local state will include one complete copy of the tree for the lowest
+level backup, plus a tree for each higher level containing only changed files,
+with links to the lower level for unchanged files. Therefore,
+<emphasis>on the client</emphasis>, storage is required for entire files
+that have been changed, but this storage is accessed at local speeds.
+From those copies, the changed regions are efficiently found, and only they
+are streamed across the network to store on the server.</para>
+
+<note><para>Most databases and similar applications will have specific steps
+that must be followed to guarantee the files are consistent before backing
+them up. Those steps may take the form of a command to create a consistent
+copy (<code>svnadmin hotcopy</code> for <application>subversion</application>,
+<code>db2bak</code> for <application>389</application>, etc.), or to enter and
+exit a mode during which a copy may safely be made
+(<code>pg_start_backup</code>/<code>pg_stop_backup</code> for
+<application>PostgreSQL</application>, etc.).</para>
+
+<para>For cases of the first type, that create a consistent copy, an
+Amanda script to run the necessary command ahead of
+<command>amopaquetree</command> may be all that is needed. The client should
+have temporary space for that consistent copy, as well as the local state space
+needed by <command>amopaquetree</command> itself. For cases of the
+second type, entering and exiting a safe-copying mode (which may require
+additional steps such as copying a write-ahead log), it may be better to
+create a specialized Amanda application by subclassing
+<classname>Amanda::Application::AmOpaqueTree</classname>.</para></note>
+</refsect1>
+
+<refsect1><title>IMPLEMENTATION</title>
+
+<para><command>amopaquetree</command> uses (and, therefore, requires)
+the widely-available <command>rsync</command> tool, both in its
+<option>--link-dest</option> mode to maintain client-local state
+limited in size to one full copy plus changed files in higher levels,
+and in its <option>--only-write-batch</option> mode to generate the
+smaller data streams, reflecting changed regions only, to be sent to
+the server.</para>
+
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control amopaquetree's
+functionality.
+See <manref name="amanda-applications" vol="7"/>
+for information on application properties and how they are configured.
+</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>LOCALSTATEDIR</term><listitem>
+Amanda has a default location for client local state, but because
+<command>amopaquetree</command> stores a larger-than-typical local state,
+this property can be used to place the local state storage on a different
+filesystem. Or, this property can be left at default, and RSYNCSTATESDIR
+(which defaults to a subdirectory of LOCALSTATEDIR) can be set, to use a
+different filesystem only for that.
+</listitem></varlistentry>
+
+ <!-- ==== -->
+ <varlistentry><term>RSYNCEXECUTABLE</term><listitem>
+Full path to the <command>rsync</command> executable on the client system.
+If elevated permission will be needed for <command>rsync</command> to read
+the tree being backed up, this can point instead to a wrapper that gains
+the needed privilege and then executes <command>rsync</command>.
+</listitem></varlistentry>
+
+ <!-- ==== -->
+ <varlistentry><term>RSYNCSTATESDIR</term><listitem>
+The directory (defaulting to a subdirectory of LOCALSTATEDIR) for the
+local copied/linked images of the tree backed up. Because this accounts
+for the greatest share of local state space, it can be separately
+redirected to another filesystem using this property.
+</listitem></varlistentry>
+
+ <!-- ==== -->
+ <varlistentry><term>RSYNCTEMPBATCHDIR</term><listitem>
+The directory where <command>rsync</command> batch files will be
+temporarily created. Temporary space must be available for the
+expected size of a batch; for a level-0 backup, that will be
+comparable to the size of a compressed archive of the tree being backed up.
+The default is where Perl's <classname>File::Temp</classname> will put
+a temporary file.
+</listitem></varlistentry>
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+<para>
+<programlisting>
+  define application-tool app_amopaquetree {
+    plugin "amopaquetree"
+  }
+</programlisting>
+A dumptype using this application might look like:
+<programlisting>
+  define dumptype amopaquetree {
+    global
+    program "APPLICATION"
+    application "app_amopaquetree"
+  }
+</programlisting>
+Note that the <emphasis>program</emphasis> parameter must be set to
+<emphasis>"APPLICATION"</emphasis> to use the <emphasis>application</emphasis>
+parameter.
+</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-applications" vol="7"/>
+<manref name="amrecover" vol="8"/>
+</seealso>
+
+</refentry>

--- a/man/xml-source/amsvnmakehotcopy.8.xml
+++ b/man/xml-source/amsvnmakehotcopy.8.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd"
+[
+  <!-- entities files to use -->
+  <!ENTITY % global_entities SYSTEM 'global.entities'>
+  %global_entities;
+]>
+
+<refentry id='amsvnmakehotcopy.8'>
+
+<refmeta>
+<refentrytitle>amsvnmakehotcopy</refentrytitle>
+<manvolnum>8</manvolnum>
+&rmi.source;
+&rmi.version;
+&rmi.manual.8;
+</refmeta>
+<refnamediv>
+<refname>amsvnmakehotcopy</refname>
+<refpurpose>Amanda script to make a Subversion hotcopy</refpurpose>
+</refnamediv>
+<refentryinfo>
+<author><personname>Chapman Flack</personname></author>
+</refentryinfo>
+<!-- body begins here -->
+
+<refsect1><title>DESCRIPTION</title>
+
+<para>amsvnmakehotcopy is an Amanda script implementing the Script API.
+It should not be run by users directly.  It uses the
+<code>svnadmin hotcopy</code> command to make a consistent copy
+of a Subversion repository.</para>
+
+<para>The filesystem path to the Subversion repository to copy is given
+in the SVNREPOSITORY property, and the consistent copy will be made into
+the directory named by <emphasis remap='B'>diskdevice</emphasis> in the
+disklist (DLE). This is the directory where the estimate and backup application
+(<manref name='amopaquetree' vol='8'/> could be appropriate) will expect to
+find the data for backup.</para>
+
+<para>The copy is made after <emphasis>removing all existing
+content under the directory named as the
+<emphasis remap='B'>diskdevice</emphasis></emphasis>, all of
+which happens during PRE-DLE-ESTIMATE, which must be set to be executed
+on the client:
+<programlisting>
+    execute-on  pre-dle-estimate
+    execute-where client
+</programlisting></para>
+
+<para>The script is run as the amanda user, and must be able to read the
+Subversion repository. Possible arrangements include making the repository
+generally readable, giving it filesystem ACLs granting the access specifically
+to the amanda user, or setting the SVNADMINEXECUTABLE property not to the
+path of <command>svnadmin</command>, but to a set-uid wrapper that obtains
+the needed permission and then executes <command>svnadmin</command> with
+the same arguments. If the wrapper approach is chosen, the wrapper should
+take all appropriate precautions to avoid being misused, such as checking
+the arguments to verify that they only request a hotcopy of
+the intended Subversion repository.</para>
+</refsect1>
+
+<refsect1><title>PROPERTIES</title>
+
+<para>This section lists the properties that control amsvnmakehotcopy's
+functionality.
+See <manref name="amanda-scripts" vol="7"/>
+for information on the Script API, script configuration.</para>
+
+<!-- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER -->
+<variablelist>
+ <!-- ==== -->
+ <varlistentry><term>SVNADMINEXECUTABLE</term><listitem>
+Path to the <command>svnadmin</command> executable, search in $PATH by default.
+If necessary to gain read access to the repository, this can be set
+instead to a set-uid wrapper that (after appropriate checks) will
+execute <command>svnadmin</command> with the same arguments.
+</listitem></varlistentry>
+ <!-- ==== -->
+ <varlistentry><term>SVNREPOSITORY</term><listitem>
+Filesystem path to the Subversion repository that is to be copied.
+</listitem></varlistentry>
+ <!-- ==== -->
+</variablelist>
+
+</refsect1>
+
+<refsect1><title>EXAMPLE</title>
+
+<para>This example defines a script <literal>svnmakehotcopy</literal>,
+a dumptype <literal>remote-svn</literal>, and a DLE to backup a particular
+repository.</para>
+
+<para>In <manref name='amanda.conf' vol='5'/>:
+<programlisting>
+ define script "svnmakehotcopy" {
+   plugin "amsvnmakehotcopy"
+   execute-where client
+   execute-on pre-dle-estimate
+ }
+
+ define dumptype remote-svn {
+   global
+   estimate client
+   program "APPLICATION"
+   application "app_amopaquetree"
+   comment "backup of remote svn repository"
+ }
+</programlisting></para>
+
+<para>In <manref name='disklist' vol='5'/>:
+<programlisting>
+  svnhost myrepo /tmp/svnmyrepocopy {
+    remote-svn
+    script {
+        "svnmakehotcopy"
+        property "svnrepository" "/var/www/svn/repos/myrepo"
+    }
+  } 1 enet100
+</programlisting></para>
+</refsect1>
+
+<refsect1><title>BUGS</title>
+<para>This script does not (yet) make any effort to detect failures.</para>
+</refsect1>
+
+<seealso>
+<manref name="amanda.conf" vol="5"/>,
+<manref name="amanda-client.conf" vol="5"/>,
+<manref name="amanda-scripts" vol="7"/>
+</seealso>
+
+
+</refentry>

--- a/perl/Amanda/Application/Abstract.pm
+++ b/perl/Amanda/Application/Abstract.pm
@@ -1,0 +1,1271 @@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+=head1 NAME
+
+Amanda::Application::Abstract - A base class for Amanda applications
+
+=head1 SYNOPSIS
+
+    package amMyAppl;
+    use base qw(Amanda::Application::Abstract)
+    
+    sub supports_message_line { return 1; }
+    ...
+    
+    sub inner_backup {
+      my ($self, $fdout) = @_;
+      ...
+    }
+    ...
+    
+    package main;
+    amMyAppl::->run();
+
+=head1 DESCRIPTION
+
+C<Amanda::Application::Abstract> handles much of the common housekeeping
+needed to implement Amanda's
+L<Application API|http://wiki.zmanda.com/index.php/Application_API>, so that
+practical applications can be implemented in few lines of code by overriding
+only a few necessary methods.
+
+C<Amanda::Application::Abstract> is itself a subclass of
+C<Amanda::Application>, but the latter cannot be instantiated until after
+the command line has been parsed (at least the C<config> option needs to be
+passed to its constructor). Therefore, C<Amanda::Application::Abstract>
+supplies I<class> methods for the preliminary work of declaring the supported
+options, parsing the command line, and finally calling C<new> to get an instance
+of the class. Then the actual operations of the application are carried out by
+instance methods, as you would expect.
+
+In perl, class methods are inheritable and overridable just as instance methods
+are, and the syntax C<$class-E<gt>SUPER::method(...)> works, analogously to its
+familiar use in an instance method. So, the pre-instantiation behavior of an
+application (declaring command options, etc.) can be tailored by simply
+overriding the necessary class methods, just as its later operations can be
+supplied by overriding instance methods.
+
+=cut
+
+package Amanda::Application::Abstract;
+use base qw(Amanda::Application);
+
+use Amanda::Feature;
+use Data::Dumper;
+use File::Path qw{make_path};
+use File::Spec;
+use Getopt::Long;
+use IO::Handle;
+use Scalar::Util qw{blessed};
+use Text::ParseWords;
+
+=head1 FUNDAMENTAL CLASS METHODS
+
+=head2 C<run>
+
+    appclass::->run()
+
+Run the application: grab the subcommand from C<ARGV[0]>, be sure it is a known
+one, set up for option parsing, parse the options, construct an instance
+passing all the supplied options (which will include the config name, needed
+by the C<Amanda::Application> constructor), and finally C<do()> the subcommand,
+where C<do> is inherited from C<Amanda::Script_App> by way of
+C<Amanda::Application>.
+
+=cut
+
+sub run {
+    my ( $class ) = @_;
+    my $subcommand = shift @ARGV || '(empty)';
+    die "Not a possible application subcommand: ".$subcommand
+    if $subcommand !~ /^(?:backup|discover|estimate|index|print|restore|selfcheck|support|validate)/;
+
+    my %opthash = ();
+    my @optspecs = ();
+
+    my $optinit = $class->can('declare_'.$subcommand.'_options');
+    die "Unsupported application subcommand: ".$subcommand if !defined $optinit;
+
+    $class->$optinit(\%opthash, \@optspecs);
+
+    my $ret = GetOptions(\%opthash, @optspecs);
+
+    # ??? Application API docs suggest that escaping can have been applied to
+    # option values, in which case here is where it should be unwrapped!
+    # First get signs of life, then test with trick values to determine
+    # exactly how values have been escaped.
+
+    # !!! pleasant surprise: option value arrived with escaping already
+    # unwrapped. Examining sendbackup debug log shows the value apparently
+    # passed to sendbackup in an escaped form, but unescaped in the section
+    # of the log file that shows "sendbackup: running ..." with the arguments
+    # logged one by one. Looks like sendbackup does the unwrapping and uses
+    # exec directly; todo: check the code to confirm.
+
+    # ... yes, that's just what sendbackup does.
+
+    my $app = $class->new(\%opthash);
+
+    $app->do($subcommand);
+}
+
+=head2 C<new>
+
+    $class->new(\%opthash)
+
+A typical application need not call this; it is called by C<run> after the
+command line options have been declared and the command line has been parsed.
+The hash reference contains option values as stored by C<GetOptions>. A certain
+convention is assumed: if there is an option/property named I<o>, its value
+will be stored in I<opthash> with key exactly I<o>, in exactly the way
+C<GetOptions> normally would, I<unless> the option-declaring method had planted
+a code reference there in order to more strictly validate the option. In that
+case, of course I<$opthash{o}> is the code reference, and the final value will
+be stored with key C<opt_>I<o> instead. Because of that convention, entries in
+I<opthash> with an C<opt_> prefix will otherwise be ignored; avoid declaring
+options/properties whose actual names start with C<opt_>.
+
+=cut
+
+sub new {
+    my ( $class, $refopthash ) = @_;
+    my %options = ();
+    for ( my ($k, $v) ; ($k, $v) = each %{$refopthash} ; ) {
+	next if $k =~ /^opt_/;
+	if ( "CODE" ne ref $v ) {
+	    $options{$k} = $v;
+	}
+	else {
+	    $options{$k} = $refopthash->{"opt_".$k}
+	}
+    }
+    my $self = $class->SUPER::new($options{'config'});
+    $self->{'options'} = \%options;
+    return $self;
+}
+
+=head1 CLASS METHODS IMPLEMENTING VARIOUS QUOTING RULES
+
+=head2 C<dquote>
+
+    $class->dquote($s)
+
+The purpose of this method is to quote a string in exactly the way that
+C<Text::ParseWords::shellquote> unquotes things, because C<shellquote> is what
+C<GetOptionsFromString> claims to use. However, the
+L<Text::ParseWords POD|Text::ParseWords> does not spell out the rules to use.
+O'Reilly's Perl Cookbook says (1.15) that "Quotation marks and backslashes are
+the only characters that have meaning backslashed. Any other use of a backslash
+will be left in the output string." ... which seems to be true, looking at the
+code, and is true of ' when ' is the quote mark, and true of " when " is the
+quote mark. That makes it actually I<not> like any common Unix shell, and also
+not like C<Amanda::Util::quote_string>, so it needs its own dedicated
+implementation here to be sure to get it right.
+
+=cut
+
+sub dquote {
+    my ( $class, $s ) = @_;
+    return $s if 1 eq scalar shellwords($s);
+    my $qs = $s;
+    $qs =~ s/([\\"])/\\$1/go;
+    $qs = '"' . $qs . '"';
+    my @parsed = shellwords($qs);
+    return $qs if 1 eq scalar @parsed and $s eq $parsed[0];
+    die 'dquote could not handle: ' . $s;
+}
+
+=head2 C<gtar_escape_quote>
+
+    $class->gtar_escape_quote($s)
+
+This method quotes a string using the same rules documented for
+GNU C<tar> in C<--quoting-style=escape> mode, as used on the index stream.
+(Note: the GNU C<tar> documentation, as of April 2016 anyway, says that space
+characters also get escaped, though GNU C<tar> has never actually done that,
+and neither does this method.)
+
+=cut
+
+sub gtar_escape_quote {
+    my ( $class, $str ) = @_;
+    $str =~ s'
+        (\a)(?{"a"})|(\f)(?{"f"})|(\n)(?{"n"})|(\r)(?{"r"})|(\t)(?{"t"})
+    |   (\010)(?{"b"})|(\013)(?{"v"})|(\177)(?{"?"})|(\\)(?{"\\"})
+    |   ([[:cntrl:]])(?{sprintf("%03o",ord($^N))})
+    'q{\\}.$^R'egox;
+    return $str;
+}
+
+=head2 C<gtar_escape_unquote>
+
+    $class->gtar_escape_unquote($s)
+
+The inverse of C<gtar_escape_quote>.
+
+=cut
+
+sub gtar_escape_unquote {
+    my ( $class, $str ) = @_;
+    $str =~ s'\\(?:
+        (a)(?{"\a"})|(f)(?{"\f"})|(n)(?{"\n"})|(r)(?{"\r"})|(t)(?{"\t"})
+    |   (b)(?{"\010"})|(v)(?{"\013"})|(\?)(?{"\177"})|(\\)(?{"\\"})
+    |   ([0-7]{1,3})(?{chr(oct($^N))})
+    )'$^R'egox;
+    return $str;
+}
+
+=head1 CLASS METHODS FOR VALIDATING OPTION/PROPERTY VALUES
+
+    ..._property_setter(\%opthash)
+
+For a common type ... return a sub that can be placed in C<%opthash>
+to validate and store a value of that type. The anonymous sub accepts the
+parameters described at "User-defined subroutines to handle options" for
+C<Getopt::Long>, and will store the validated, converted option value in
+I<%opthash> at a key derived by prefixing C<opt_> to the option name.
+For example, a C<declare_common_options> method that defines a boolean
+property I<foo> may contain the snippet:
+
+    $refopthash->{'foo'} = $class->boolean_property_setter($refopthash);
+
+At present, properties with scalar or hash values can be supported (the
+setter sub can tell by the number of parameters passed to it by
+C<Getopt::Long>), but not multiple-valued ones accumulating into an array
+(which can't be distinguished from the scalar case just by looking at what
+comes from C<Getopt::Long>).
+
+=head2 C<boolean_property_setter>
+
+Allows the same boolean literals described in C<amanda.conf(5)>:
+C<1>, C<y>, C<yes>, C<t>, C<true>, C<on> or
+C<0>, C<n>, C<no>, C<f>, C<false>, C<off>, case-insensitively.
+
+=cut
+
+sub boolean_property_setter {
+    my ( $class, $refopthash ) = @_;
+    return sub {
+	my ( $optname, $k, $v, $b );
+	$optname = shift;
+	$k = shift if 2 == scalar(@_);
+	$v = shift;
+	if ( $v =~ /^(?:1|y|yes|t|true|on)$/i ) {
+            $b = 1;
+	}
+	elsif ( $v =~ /^(?:0|n|no|f|false|off)$/i ) {
+	    $b = 0;
+	}
+	else {
+	    die 'invalid value ' . Amanda::Util::quote_string($v) .
+	        ' for boolean property ' .
+	        Amanda::Util::quote_string("$optname");
+	}
+	if ( defined $k ) {
+	    $refopthash->{'opt_'.$optname}->{$k} = $b;
+	}
+	else {
+	    $refopthash->{'opt_'.$optname} = $b;
+	}
+    };
+}
+
+=head1 CLASS METHODS FOR DECLARING ALLOWED OPTIONS
+
+    declare_..._options(\%opthash, \@optspecs)
+
+Each of these is a class method that is passed two references: a hash reference
+I<\%opthash> and a list reference I<\@optspecs>. It should push onto
+I<\@optspecs> the declarations of whatever options are valid for the
+corresponding subcommand, using the syntax described in L<Getopt::Long>.
+It does not need to touch I<\%opthash>, but may store a code reference at the
+name of any option, to apply stricter validation when the option is parsed.
+In that case, the code reference should ultimately store the validated value
+into I<\%opthash> at a key derived by prefixing C<opt_> to the option name.
+
+For each valid I<subcommand>, there must be a
+C<declare_>I<subcommand>C<_options> class method, which will be called
+by C<run> just before trying to parse the command line.
+
+=head2 C<declare_common_options>
+
+Declare the options common to every subcommand. This is called by
+every other C<declare_>I<foo>C<_options> method, and, if not overridden itself,
+simply declares the C<config>, C<host>, C<disk>, C<device> options that
+(almost?) every subcommand ought to support.
+
+A subclass that has properties of its own should probably declare them here
+rather than in more-specific C<declare_>I<foo>C<_options> methods, as whatever
+properties are set in the Amanda configuration could be passed along for any
+subcommand; Amanda won't know which subcommands need them and which don't.
+
+=cut
+
+sub declare_common_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    push @$refoptspecs, ( 'config=s', 'host=s', 'disk=s', 'device=s' );
+}
+
+=head2 C<declare_support_options>
+
+Declare options for the C<support> subcommand. Only the C<common> ones.
+
+=cut
+
+sub declare_support_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->declare_common_options($refopthash, $refoptspecs);
+}
+
+=head2 C<declare_backup_options>
+
+Declare options for the C<backup> subcommand. Unless overridden, this simply
+declares the C<common> ones plus C<message>, C<index>, C<level>, C<record>, and
+C<state-stream>.
+
+=cut
+
+sub declare_backup_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->declare_common_options($refopthash, $refoptspecs);
+    push @$refoptspecs, (
+        'message=s', 'index=s', 'level=i', 'record', 'state-stream=i' );
+}
+
+=head2 C<declare_restore_options>
+
+Declare options for the C<restore> subcommand. Unless overridden, this simply
+declares the C<common> ones plus C<message>, C<index>, C<level>, C<dar>, and
+C<recover-dump-state-file>.
+
+=cut
+
+sub declare_restore_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->declare_common_options($refopthash, $refoptspecs);
+    push @$refoptspecs, (
+        'message=s', 'index=s', 'level=i',
+	'dar=s', 'recover-dump-state-file=s' );
+    $refopthash->{'dar'} = sub {
+        my ( $optname, $optval ) = @_;
+	if ( $optval eq 'YES' ) {
+	    $refopthash->{'opt_'.$optname} = 1;
+	}
+	elsif ( $optval eq 'NO' ) {
+	    $refopthash->{'opt_'.$optname} = 0;
+	}
+	else {
+	    die "--$optname requires YES or NO";
+	}
+    };
+}
+
+=head2 C<declare_index_options>
+
+Declare options for the C<index> subcommand. Unless overridden, this simply
+declares the C<common> ones plus C<message>, C<index>, C<level>.
+
+=cut
+
+sub declare_index_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->declare_common_options($refopthash, $refoptspecs);
+    push @$refoptspecs, (
+        'message=s', 'index=s', 'level=i' );
+}
+
+=head2 C<declare_estimate_options>
+
+Declare options for the C<estimate> subcommand. Unless overridden, this simply
+declares the C<common> ones plus C<message> and C<level>.
+If C<$class-E<gt>supports('multi_estimate')> then C<level> will be declared to
+allow multiple uses.
+
+=cut
+
+sub declare_estimate_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->declare_common_options($refopthash, $refoptspecs);
+    push @$refoptspecs, (
+        'message=s', 'level=i'.($class->supports('multi_estimate') ? '@' : '' )
+    );
+}
+
+=head2 C<declare_selfcheck_options>
+
+Declare options for the C<selfcheck> subcommand. Unless overridden, this simply
+declares the C<common> ones plus C<message>, C<level>, and C<record>.
+
+=cut
+
+sub declare_selfcheck_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    $class->declare_common_options($refopthash, $refoptspecs);
+    push @$refoptspecs, ('message=s', 'index=s', 'level=i', 'record');
+}
+
+=head2 C<declare_validate_options>
+
+Declare options for the C<validate> subcommand. Unless overridden, this
+declares no options at all.
+
+=cut
+
+sub declare_validate_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+}
+
+=head1 CLASS METHODS SUPPORTING C<support> SUBCOMMAND
+
+These class methods establish the default capabilities advertised by the
+C<support> subcommand. A particular application can supply I<class> methods
+to override them. Most are boolean and an absent one is treated as returning
+C<false>. Therefore, the only ones that need to be supplied here are the
+non-booleans, and the booleans with non-C<false> defaults.
+
+=head2 C<recover_mode>
+
+Should return either C<undef> or C<'SMB'>. Default if not overridden
+is C<undef>.
+
+=cut
+
+sub recover_mode { my ( $class ) = @_; return undef; }
+
+=head2 C<data_path>
+
+Should return a list of C<'AMANDA'>, C<'DIRECTTCP'>, or both.
+Default if not overridden is C<'AMANDA'>.
+
+=cut
+
+sub data_path { my ( $class ) = @_; return ("AMANDA"); }
+
+=head2 C<recover_path>
+
+Should return C<'CWD'> or C<'REMOTE'>. Default if not overridden is C<CWD>.
+
+=cut
+
+sub recover_path { my ( $class ) = @_; return "CWD"; }
+
+=head2 C<supports>
+
+    $class->supports(name)
+
+Returns C<false> if there is no C<supports_>I<name>C<()> class method,
+otherwise calls it and returns its result.
+
+=cut
+
+sub supports {
+    my ( $class, $supname ) = @_;
+    my $s = $class->can("supports_".$supname);
+    return (defined $s) and $s;
+}
+
+=head1 INSTANCE METHODS SUPPORTING C<support> SUBCOMMAND
+
+=head2 C<max_level>
+
+Returns the maximum C<level> supported, Default if not overridden is zero,
+indicating no support for incremental backup. An instance method because the
+value could depend on state only known after instantiation.
+
+=cut
+
+sub max_level { my ( $self ) = @_; return 0; }
+
+#
+# Private instance method to produce a support-line for a boolean
+# capability:  $self->say_supports($confstring, $supname) where $confstring
+# is the text to output on fd1, followed by a space and YES or NO and a
+# newline, as determined by calling $class->supports($supname).
+#
+
+my $say_supports = sub {
+    my ( $self, $confstring, $supname ) = @_;
+    my $yn = blessed($self)->supports($supname) ? "YES" : "NO";
+    print $confstring . " " . $yn . "\n";
+};
+
+#
+# Private instance methods used only to sanity-check return values in case
+# certain "supports" methods are overridden:
+#
+
+# recover_mode (class method) should return either undef or "SMB"
+my $checked_recover_mode = sub {
+    my ( $self ) = @_;
+    my $rm = blessed($self)->recover_mode();
+    die "unusable recover_mode: ".$rm if defined $rm and $rm ne "SMB";
+    return $rm;
+};
+
+# data_path (class method) should return list: "AMANDA", "DIRECTTCP", or both
+my $checked_data_path = sub {
+    my ( $self ) = @_;
+    my @dp = blessed($self)->data_path();
+    my $dpl = scalar @dp;
+    die "unusable data_path: ".Dumper(\@dp)
+        if $dpl lt 1 or 0 lt grep(!/^(?:AMANDA|DIRECTTCP)$/, @dp);
+    return @dp;
+};
+
+# recover_path (class method) should return either "CWD" or "REMOTE"
+my $checked_recover_path = sub {
+    my ( $self ) = @_;
+    my $rp = blessed($self)->recover_path();
+    die "unusable recover_path: ".$rp
+        unless defined $rp and $rp =~ /^(?:CWD|REMOTE)$/;
+    return $rp;
+};
+
+# max_level (instance method) should return 0..99
+my $checked_max_level = sub {
+    my ( $self ) = @_;
+    my $mxl = $self->max_level();
+    die "unusable max_level: ".$mxl unless defined $mxl and $mxl =~ /^\d\d?$/;
+    return 0 + $mxl;
+};
+
+=head1 INSTANCE METHODS SUPPORTING LOCAL PERSISTENT STATE
+
+These methods establish a conventional location for a local state file,
+and a default format for its contents. To avoid relying on non-core modules
+(even JSON isn't a sure thing yet), the default format relies on writing
+name/value pairs to the file in a form C<Getopt::Long> can recover.
+
+By default, a state is a hash with integer keys representing levels, plus one
+string key, C<maxlevel>. The value for C<maxlevel> is an integer, and for each
+integer key I<level>, the value is a hashref that contains
+(redundantly) C<'level' =E<gt> >I<level> plus whatever other name/value pairs
+the application wants.
+
+=head2 C<local_state_path>
+
+    ($dirpart, $filepart) = $self->local_state_path()
+
+Supplies a reasonable location for storing local state for the subject DLE.
+If not overridden, returns a I<$dirpart> based on
+C<$Amanda::Paths::localstatedir> followed by C<Amanda::Util::hexencode>d
+components based on C<config>, C<host>, C<disk>, and C<device> if present, and a
+I<$filepart> based on the application name.
+
+=cut
+
+sub local_state_path {
+    my ( $self ) = @_;
+    return $self->build_state_path($Amanda::Paths::localstatedir);
+}
+
+=head2 C<build_state_path>
+
+    ($dirpart, $filepart) = $self->build_state_path($basedir)
+
+Does the actual building of a local state path (as described above for
+C<local_state_path>) given a base directory, so that a subclass can easily
+override C<local_state_path> to use a different base directory, but otherwise
+build the rest of the path the same way.
+
+=cut
+
+sub build_state_path {
+    my ( $self, $basedir ) = @_;
+    my @components = ( $basedir, $self->{'type'} );
+    my $c = $self->{'options'}->{'config'};
+    push @components, 'c-'.Amanda::Util::hexencode($c) if defined $c;
+    $c = $self->{'options'}->{'host'};
+    push @components, 'h-'.Amanda::Util::hexencode($c) if defined $c;
+    $c = $self->{'options'}->{'disk'};
+    push @components, 'd-'.Amanda::Util::hexencode($c) if defined $c;
+    $c = $self->{'options'}->{'device'};
+    push @components, 'v-'.Amanda::Util::hexencode($c) if defined $c;
+    return File::Spec->catdir(@components),
+        Amanda::Util::hexencode($self->{'name'});
+}
+
+=head2 C<read_local_state>
+
+    $hashref = $self->read_local_state(\@optspecs)
+
+Read a local state, if present, returning it in I<$hashref>. In the returned
+state, the value for C<maxlevel> represents the maximum level of incremental
+I<backup> that could be requested, namely, one plus the maximum previous level
+represented in the state. If no stored state is found, a state hash is returned
+with C<maxlevel> of zero and no other data. Otherwise, the file is parsed for
+one or more levels of saved state, by repeatedly applying C<Getopt::Long> with
+I<\@optspecs> to declare the application's allowed options.
+
+=cut
+
+sub read_local_state {
+    my ( $self, $optspecs ) = @_;
+    my ( $dirpart, $filepart ) = $self->local_state_path();
+    my $ret = open my $fh, '<', File::Spec->catfile($dirpart, $filepart);
+    if ( ! $ret ) {
+    	my %empty = ( 'maxlevel' => 0 );
+	return \%empty;
+    }
+    my $slurped;
+    {
+        local $/;
+	$slurped = <$fh>;
+    }
+    close $fh;
+    my $opthash = {};
+    my $maxlevel = 0;
+    my %result;
+    my $remain;
+    ( $ret, $remain ) =
+        Getopt::Long::GetOptionsFromString($slurped, $opthash, @$optspecs);
+    # XXX carp if remain[0] doesn't start with --
+    my $lev = $opthash->{'level'};
+    $maxlevel = $lev if $lev > $maxlevel;
+    $result{$lev} = $opthash;
+    while ( 0 < scalar @$remain ) {
+        $opthash = {};
+	$ret = Getopt::Long::GetOptionsFromArray($remain, $opthash, @$optspecs);
+	$lev = $opthash->{'level'};
+        $maxlevel = $lev if $lev > $maxlevel;
+        $result{$lev} = $opthash;
+    }
+    $result{'maxlevel'} = 1 + $maxlevel;
+    return \%result;
+}
+
+=head2 C<write_local_state>
+
+    $self->write_local_state(\%levhash)
+
+Save the local state represented by I<\%levhash>, creating the file and
+intermediate directories if necessary. C<Amanda::Util::safe_overwrite_file>
+is used to avoid leaving partially-overwritten state.
+
+=cut
+
+sub write_local_state {
+    my ( $self, $levhash ) = @_;
+    my $state = '';
+    for ( my ($level, $opthash); ($level, $opthash) = each %$levhash; ) {
+        next if 'maxlevel' eq $level;
+	$state .= '--level ' . $level . "\n";
+	for ( my ($k, $v); ($k, $v) = each %$opthash; ) {
+	    next if 'level' eq $k;
+	    $state .= $self->dquote('--'.$k).' '.$self->dquote($v)."\n";
+	}
+	$state .= "--\n";
+    }
+    my ( $dirpart, $filepart ) = $self->local_state_path();
+    make_path($dirpart);
+    Amanda::Util::safe_overwrite_file(File::Spec->catfile($dirpart, $filepart),
+                                      $state);
+}
+
+=head2 C<update_local_state>
+
+    $self->update_local_state(\%state, $level, \%opthash)
+
+Given a I<\%state> (which contains C<'maxlevel' =E<gt> >(I<n>+1) as well as
+I<k>C< =E<gt> >I<(opthash for level k)> for I<k> in 0..n), and a new
+I<$level> and corresponding I<\%opthash> for that level, change
+C<maxlevel> to 1 + I<$level>, drop all entries for levels above
+I<$level>, and install the new I<\%opthash> at I<$level>.
+
+=cut
+
+sub update_local_state {
+    my ( $self, $state, $level, $opthash ) = @_;
+    for ( my ($l, $oh); ($l, $oh) = each %$state; ) {
+        next if 'maxlevel' eq $l or (0 + $l) le $level;
+	delete $state->{$l};
+    }
+    $state->{'maxlevel'} = 1 + $level;
+    $state->{$level} = $opthash;
+}
+
+=head1 INSTANCE METHODS IMPLEMENTING SUBCOMMANDS
+
+=head2 C<command_support>
+
+As long as the application class overrides the methods indicating its
+support for these capabilities, this default implementation will take care
+of producing output in the proper format.
+
+=cut
+
+sub command_support {
+    my ( $self ) = @_;
+
+    $self->$say_supports(	    "CONFIG", "config");
+    $self->$say_supports(	      "HOST", "host");
+    $self->$say_supports(	      "DISK", "disk");
+    $self->$say_supports(	"INDEX-LINE", "index_line");
+    $self->$say_supports(	 "INDEX-XML", "index_xml");
+    $self->$say_supports(     "MESSAGE-LINE", "message_line");
+    $self->$say_supports(      "MESSAGE-XML", "message_xml");
+    $self->$say_supports(	    "RECORD", "record");
+    $self->$say_supports(     "INCLUDE-FILE", "include_file");
+    $self->$say_supports(     "INCLUDE-LIST", "include_list");
+    $self->$say_supports("INCLUDE-LIST-GLOB", "include_list_glob");
+    $self->$say_supports( "INCLUDE-OPTIONAL", "include_optional");
+    $self->$say_supports(     "EXCLUDE-FILE", "exclude_file");
+    $self->$say_supports(     "EXCLUDE-LIST", "exclude_list");
+    $self->$say_supports("EXCLUDE-LIST-GLOB", "exclude_list_glob");
+    $self->$say_supports( "EXCLUDE-OPTIONAL", "exclude_optional");
+    $self->$say_supports(	"COLLECTION", "collection");
+    $self->$say_supports(	  "CALCSIZE", "calcsize");
+    $self->$say_supports(  "CLIENT-ESTIMATE", "client_estimate");
+    $self->$say_supports(   "MULTI-ESTIMATE", "multi_estimate");
+
+    print "MAX-LEVEL ".($self->$checked_max_level())."\n";
+
+    my $rcvrmode = $self->$checked_recover_mode();
+    print "RECOVER-MODE ".$rcvrmode."\n" if defined $rcvrmode;
+
+    for my $dp ($self->$checked_data_path()) {
+        print "DATA-PATH ".$dp."\n";
+    }
+
+    print "RECOVER-PATH ".($self->$checked_recover_path())."\n";
+
+    $self->$say_supports(             "AMFEATURES", "amfeatures");
+    $self->$say_supports("RECOVER-DUMP-STATE-FILE", "recover_dump_state_file");
+    $self->$say_supports(                    "DAR", "dar");
+    $self->$say_supports(           "STATE-STREAM", "state_stream");
+}
+
+=head2 METHODS FOR THE C<backup> SUBCOMMAND
+
+=head3 C<check_message_index_options>
+
+Check sanity of the (standard) options parsed from the command line
+for C<--message> and C<--index>.
+
+=cut
+
+sub check_message_index_options {
+    my ( $self ) = @_;
+
+    my $msg = $self->{'options'}->{'message'};
+    if ( ! defined $msg and $self->supports('message_line') ) {
+        $self->{'options'}->{'message'} = 'line';
+    }
+    elsif ( 'line' eq $msg and $self->supports('message_line') ) {
+        # jolly
+    }
+    elsif ( 'xml' ne $msg or ! $self->supports('message_xml') ) {
+        $self->print_to_server('invalid --message '.$msg,
+	                       $Amanda::Script_App::ERROR);
+    }
+
+    my $idx = $self->{'options'}->{'index'};
+    if ( ! defined $idx and $self->supports('index_line') ) {
+        $self->{'options'}->{'index'} = 'line';
+    }
+    elsif ( 'line' eq $idx and $self->supports('index_line') ) {
+        # jolly
+    }
+    elsif ( 'xml' ne $idx or ! $self->supports('index_xml') ) {
+        $self->print_to_server('invalid --index '.$idx,
+	                       $Amanda::Script_App::ERROR);
+    }
+}
+
+=head3 C<check_backup_options>
+
+Check sanity of the (standard) options parsed from the command line
+for a C<backup> operation. Override to check any additional properties
+for the application.
+
+=cut
+
+sub check_backup_options {
+    my ( $self ) = @_;
+
+    $self->check_message_index_options();
+    $self->check_level_option();
+
+    if ( $self->{'options'}->{'record'} and ! $self->supports('record') ) {
+        $self->print_to_server('not supported --record',
+	                       $Amanda::Script_App::ERROR);
+    }
+}
+
+=head3 C<check_level_option>
+
+Check sanity of C<--level> option(s) parsed from the command line.
+In order to work in cases that do or don't support C<multi_estimate>,
+this will check either a single value that isn't an array, or every
+element of a value that's an array reference.
+
+=cut
+
+sub check_level_option {
+    my ( $self ) = @_;
+
+    my $lvls = $self->{'options'}->{'level'};
+    return if !defined($lvls);
+    $lvls = [ $lvls ] if ref($lvls) ne 'ARRAY';
+
+    for my $lvl (@$lvls) {
+        if ( 0 > $lvl  or  $lvl > $self->max_level() ) {
+            $self->print_to_server('out of range --level '.$lvl,
+	                           $Amanda::Script_App::ERROR);
+        }
+    }
+}
+
+=head3 C<emit_index_entry>
+
+    $self->emit_index_entry($name)
+
+Write I<$name> to the index stream. The caller is responsible to make sure
+that I<$name> begins with a C</>, is relative to the I<--device>, and ends
+with a C</> if it is a directory. Otherwise it should be the exact name that
+the OS would be given to open the file. This method will handle quoting
+any special characters in the name as needed within the index file. It will use
+the same quoting rules as GNU C<tar> in C<--quoting-style=escape> mode.
+
+=cut
+
+sub emit_index_entry {
+    my ( $self, $name ) = @_;
+    die 'default emit_index_entry supports only "line"'
+    	unless 'line' eq $self->{'options'}->{'index'};
+    $self->{'index_out'}->print(blessed($self)->gtar_escape_quote($name)."\n");
+}
+
+=head3 C<command_backup>
+
+Performs common housekeeping tasks, calling C<inner_backup> to do the
+application's real work. First calls C<check_backup_options> to verify
+the invocation, creates the C<index_out> file handle, and calls
+C<inner_backup> passing the fd to use for output.
+
+On return from C<inner_backup>, closes the output fd and the index handle,
+and writes the C<sendbackup: size> line based on the size in bytes returned
+by C<inner_backup> (unless the returned size is negative, in which case no
+C<sendbackup> line is written).
+
+=cut
+
+sub command_backup {
+    my ( $self ) = @_;
+    $self->check_backup_options();
+
+    $self->{'index_out'} = IO::Handle->new_from_fd(4, 'w');
+
+    my $fdout = fileno(STDOUT);
+    my $size = $self->inner_backup($fdout);
+    POSIX::close($fdout);
+
+    $self->{'index_out'}->close;
+    if ($size->bcmp(0) >= 0) {
+	my $ksize = $size->copy()->badd(1023)->bdiv(1024);
+	if ($ksize->bcmp(32) < 0) {
+	    $ksize = 32; # no need to represent 32 as a BigInt....
+	} else {
+	    $ksize = $ksize->bstr();
+	}
+	print {$self->{mesgout}} "sendbackup: size $ksize\n";
+    }
+
+    # Here's a kludge for you ... the same commit that created the
+    # sendbackup_crc feature (a4e01f9) also shifted the responsibility for
+    # sending the "end" line, so it will be done for us in sendbackup.c.
+    # If using this module in an older Amanda without that feature, it still
+    # has to be sent here.
+
+    if ( !defined $Amanda::Feature::fe_sendbackup_crc ) {
+        print {$self->{mesgout}} "sendbackup: end\n";
+    }
+}
+
+=head3 C<inner_backup>
+
+    $size = $self->inner_backup($outfd)
+
+In many cases, the application should only need to override this method to
+perform a backup. The backup stream should be written to I<$outfd>, and the
+number of bytes written should be returned, as a C<Math::BigInt>.
+
+If not overridden, this default implementation writes nothing and returns zero.
+
+=cut
+
+sub inner_backup {
+    my ( $self, $outfd ) = @_;
+    return Math::BigInt->bzero();
+}
+
+=head3 C<shovel>
+
+    $size = $self->shovel($fdfrom, $fdto)
+
+Shovel all the available bytes from I<$fdfrom> to I<$fdto>, returning the
+number of bytes shoveled as a C<Math::BigInt>.
+
+=cut
+
+sub shovel {
+    my ( $self, $fdfrom, $fdto ) = @_;
+    my $size = Math::BigInt->bzero();
+    my $s;
+    my $buffer;
+    while (($s = POSIX::read($fdfrom, $buffer, 32768)) > 0) {
+	Amanda::Util::full_write($fdto, $buffer, $s);
+	$size->badd($s);
+    }
+    return $size;
+}
+
+=head2 METHODS FOR THE C<restore> SUBCOMMAND
+
+=head3 C<check_restore_options>
+
+Check sanity of the (standard) options parsed from the command line
+for a C<restore> operation. Override to check any additional properties
+for the application.
+
+=cut
+
+sub check_restore_options {
+    my ( $self ) = @_;
+
+    $self->check_message_index_options();
+
+    $self->check_level_option();
+
+    my $dar = $self->{'options'}->{'opt_dar'}; # {'dar'} is a code ref
+    my $rdsf = $self->{'options'}->{'recover_dump_state_file'};
+
+    if ( $dar and ! $self->supports('dar') ) {
+        $self->print_to_server('not supported --dar',
+	                       $Amanda::Script_App::ERROR);
+    }
+
+    if ( $rdsf and ! $self->supports('recover_dump_state_file') ) {
+        $self->print_to_server('not supported --recover-dump-state-file',
+	                       $Amanda::Script_App::ERROR);
+    }
+
+    if ( $dar xor $rdsf ) {
+        $self->print_to_server(
+	    '--dar=YES and --recover-dump-state-file only make sense together',
+	                       $Amanda::Script_App::ERROR);
+    }
+}
+
+=head3 C<emit_dar_request>
+
+    $self->emit_dar_request($offset, $size)
+
+A C<restore> subcommand that supports Direct Access Recovery can be passed
+C<--dar YES> and C<--recover-dump-state-file >I<filename>, read the I<filename>
+to recover the backup stream position information saved at backup time, then
+look up the names requested for restoration to determine what ranges of the
+backup stream will actually be needed to complete the recovery. It calls
+C<emit_dar_request> once for each contiguous range needed; I<$offset> and
+I<$size> are both in units of bytes.
+
+=cut
+
+sub emit_dar_request {
+    my ( $self, $offset, $size ) = @_;
+    $self->{'dar_out'}->print('DAR '.$offset->bstr().':'.$size->bstr()."\n");
+}
+
+=head3 C<command_restore>
+
+Performs common housekeeping tasks, calling C<inner_restore> to do the
+application's real work. First calls C<check_restore_options> to verify
+the invocation. If DAR is supported and requested, opens the
+recover-state-file for reading and the DAR stream for writing.
+Changes directory to C<Amanda::Util::get_original_cwd()>, or to the value of
+a C<--directory> property if the application declared such an option and it
+was seen on the command line.
+
+Calls C<inner_restore> passing the input stream fileno, the recover-state-file
+handle (or C<undef> if DAR was not requested), and the command-line arguments
+(indicating objects to be restored); that is, C<inner_restore> has a
+variable-length argument list after the first two.
+
+On return from C<inner_restore>, closes the recover-state-file and DAR handles
+if used.
+
+=cut
+
+sub command_restore {
+    my ( $self ) = @_;
+    $self->check_restore_options();
+
+    my $dsf;
+    my $rdsf = $self->{'options'}->{'recover-dump-state-file'};
+    if ( defined $rdsf ) {
+        open $dsf, '<', $rdsf;
+	if ( !defined $dsf ) {
+	    $self->print_to_server_and_die("Can't open '$rdsf': $!",
+				       $Amanda::Script_App::ERROR);
+	}
+        $self->{'dar_out'} = IO::Handle->new_from_fd(3, 'w');
+    }
+
+    chdir(Amanda::Util::get_original_cwd());
+    if (defined $self->{directory}) {
+        if (!-d $self->{directory}) {
+            $self->print_to_server_and_die("Directory $self->{directory}: $!",
+                                           $Amanda::Script_App::ERROR);
+        }
+        if (!-w $self->{directory}) {
+            $self->print_to_server_and_die("Directory $self->{directory}: $!",
+                                           $Amanda::Script_App::ERROR);
+        }
+        chdir($self->{directory});
+    }
+
+    # XXX at this point, names-to-restore in @ARGV may need some unescaping
+    # done. First get signs of life, then test how Amanda is in fact passing
+    # them, to determine what is needed.
+
+    $self->inner_restore(fileno(STDIN), $dsf, @ARGV);
+
+    if ( defined $dsf ) {
+        close $dsf;
+	close $self->{'dar_out'};
+    }
+}
+
+=head3 C<inner_restore>
+
+    $self->inner_restore($infd, $dsf, $filetorestore...)
+
+Should be overridden to do the actual restoration. Reads stream from I<$infd>,
+restores objects represented by the I<$filetorestore> arguments. If the
+application supports DAR, should check I<$dsf>: if it is defined, it is a
+readable file handle; read the state from it and then call C<emit_dar_request>
+to request the needed backup stream regions to recover the wanted objects.
+
+If not overridden, this default implementation reads, and does, nothing.
+
+=cut
+
+sub inner_restore {
+    my $self = shift;
+    my $fdin = shift;
+    my $dsf = shift;
+}
+
+=head2 METHODS FOR THE C<index> SUBCOMMAND
+
+=head3 C<check_index_options>
+
+Check sanity of the (standard) options parsed from the command line
+for an C<index> operation. Override to check any additional properties
+for the application.
+
+=cut
+
+sub check_index_options {
+    my ( $self ) = @_;
+
+    $self->check_message_index_options();
+    $self->check_level_option();
+}
+
+=head3 C<command_index>
+
+Performs common housekeeping tasks, calling C<inner_index> to do the
+application's real work. First calls C<check_index_options> to verify
+the invocation.
+
+Calls C<inner_index>, which is expected to read from C<STDIN>.
+
+On return from C<inner_index>, closes the index-out stream.
+
+=cut
+
+sub command_index {
+    my ( $self ) = @_;
+    $self->check_index_options();
+
+    $self->{'index_out'} = IO::Handle->new_from_fd(1, 'w');
+    $self->inner_index();
+
+    $self->{'index_out'}->close;
+}
+
+=head3 C<inner_index>
+
+    $self->inner_index()
+
+Should be overridden to read from C<STDIN> and call C<emit_index_entry> for
+each user object represented.
+
+If not overridden, this default implementation reads everything from C<STDIN>
+and emits a single entry for C</>.
+
+=cut
+
+sub inner_index {
+    my $self = shift;
+    $self->emit_index_entry('/');
+    $self->default_validate(); # which happens to read all STDIN and do nothing
+}
+
+=head2 METHODS FOR THE C<estimate> SUBCOMMAND
+
+=head3 C<check_estimate_options>
+
+Check sanity of the (standard) options parsed from the command line
+for an C<estimate> operation. Override to check any additional properties
+for the application.
+
+=cut
+
+sub check_estimate_options {
+    my ( $self ) = @_;
+
+    $self->check_message_index_options();
+    $self->check_level_option();
+}
+
+=head3 C<command_estimate>
+
+Performs common housekeeping tasks, calling C<inner_estimate> to do the
+application's real work. First calls C<check_estimate_options> to verify
+the invocation.
+
+Calls C<inner_estimate> once (for each level, in case of C<multi_estimate>),
+which should return a C<Math::BigInt> size in bytes. Writes each size to the
+output stream in the required format, assuming a block size of 1K.
+
+=cut
+
+sub command_estimate {
+    my ( $self ) = @_;
+    $self->check_estimate_options();
+
+    my $lvls = $self->{'options'}->{'level'};
+    if ( !defined $lvls ) {
+        $self->print_to_server_and_die("Can't estimate without --level");
+    }
+
+    my $isArray = ref($lvls) eq 'ARRAY';
+    if ( $isArray xor blessed($self)->supports('multi_estimate') ){
+        $self->print_to_server_and_die(
+	    "--level usage does not match multi_estimate support");
+    }
+    $lvls = [ $lvls ] if ! $isArray;
+
+    for my $lvl ( @$lvls ) {
+        my $size = $self->inner_estimate($lvl);
+	if ( $size->bcmp(0) < 0 ) {
+	    print "$lvl -1 -1\n";
+	} else {
+	    my $ksize = $size->copy()->badd(1023)->bdiv(1024);
+            $ksize = ($ksize->bcmp(32) < 0) ? 32 : $ksize->bstr();
+	    print "$lvl $ksize 1\n";
+	}
+    }
+}
+
+=head3 C<inner_estimate>
+
+Takes one parameter (the level) and returns a C<Math::BigInt> estimating
+the backup size in bytes.
+
+If not overridden, this default implementation does nothing but return zero.
+Hey, it's an estimate.
+
+=cut
+
+sub inner_estimate {
+    my ($self, $level) = @_;
+    return Math::BigInt->bzero();
+}
+
+=head2 METHODS FOR THE C<selfcheck> SUBCOMMAND
+
+=head3 C<check_selfcheck_options>
+
+Check sanity of the (standard) options parsed from the command line
+for a C<selfcheck> operation. Override to check any additional properties
+for the application. If not overridden, this checks the same things as
+C<check_backup_options>.
+
+=cut
+
+sub check_selfcheck_options {
+    my ( $self ) = @_;
+
+    $self->check_backup_options();
+}
+
+=head3 C<command_selfcheck>
+
+If not overridden, this simply checks the options and writes a GOOD message.
+
+=cut
+
+sub command_selfcheck {
+    my ( $self ) = @_;
+    $self->check_selfcheck_options();
+    $self->print_to_server("$self->{name} (non-overridden selfcheck)",
+                           $Amanda::Script_App::GOOD);
+}
+
+=head2 METHODS FOR THE C<validate> SUBCOMMAND
+
+=head3 C<command_validate>
+
+If not overridden, this simply reads the complete data stream
+and does nothing with it. (Which is just what would happen if this sub
+were absent and the invocation fell back to C<default_validate>, but
+providing this sub allows subclasses to refer to it with SUPER and not
+have to think about whether C<command_validate> or C<default_validate>
+is the right thing to call.)
+
+=cut
+
+sub command_validate {
+    my ( $self ) = @_;
+    $self->default_validate();
+}
+
+1;

--- a/perl/Amanda/Script/Abstract.pm
+++ b/perl/Amanda/Script/Abstract.pm
@@ -1,0 +1,188 @@
+# This copyright apply to all codes written by authors that made contribution
+# made under the BSD license.  Read the AUTHORS file to know which authors made
+# contribution made under the BSD license.
+#
+# The 3-Clause BSD License
+
+# Copyright 2017 Purdue University
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+=head1 NAME
+
+Amanda::Script::Abstract - A base class for Amanda scripts
+
+=head1 SYNOPSIS
+
+    package amMyScript;
+    use base qw(Amanda::Script::Abstract)
+
+    package main;
+    amMyScript::->run();
+
+=head1 DESCRIPTION
+
+C<Amanda::Script::Abstract> handles much of the common housekeeping
+needed to implement Amanda's
+L<Script API|http://wiki.zmanda.com/index.php/Script_API>, so that
+practical applications can be implemented in few lines of code by overriding
+only a few necessary methods.
+
+C<Amanda::Script::Abstract> is itself a subclass of
+C<Amanda::Script>, but the latter cannot be instantiated until after
+the command line has been parsed (at least the I<execute-where> argument and
+C<config> options need to be
+passed to its constructor). Therefore, C<Amanda::Script::Abstract>
+supplies I<class> methods for the preliminary work of declaring the supported
+options, parsing the command line, and finally calling C<new> to get an instance
+of the class. Then the actual operations of the script are carried out by
+instance methods, as you would expect.
+
+In perl, class methods are inheritable and overridable just as instance methods
+are, and the syntax C<$class-E<gt>SUPER::method(...)> works, analogously to its
+familiar use in an instance method. So, the pre-instantiation behavior of a
+script (declaring command options, etc.) can be tailored by simply
+overriding the necessary class methods, just as its later operations can be
+supplied by overriding instance methods.
+
+=cut
+
+package Amanda::Script::Abstract;
+use base qw(Amanda::Script);
+
+use Amanda::Feature;
+use Data::Dumper;
+use File::Path qw{make_path};
+use File::Spec;
+use Getopt::Long;
+use IO::Handle;
+use Scalar::Util qw{blessed};
+use Text::ParseWords;
+
+=head1 FUNDAMENTAL CLASS METHODS
+
+=head2 C<run>
+
+    scriptclass::->run()
+
+Run the script: grab the I<execute-where> from C<ARGV[0]>, be sure it is a known
+one, set up for option parsing, parse the options, construct an instance
+passing all the supplied options (which will include the config name, needed
+by the C<Amanda::Script> constructor), and finally C<do()> the I<execute-where>,
+where C<do> is inherited from C<Amanda::Script_App> by way of
+C<Amanda::Script>.
+
+=cut
+
+sub run {
+    my ( $class ) = @_;
+    my $execute_where = shift @ARGV || '(empty)';
+
+    my %opthash = ();
+    my @optspecs = ();
+
+    $class->declare_options(\%opthash, \@optspecs);
+
+    my $ret = GetOptions(\%opthash, @optspecs);
+
+    # !!! pleasant surprise: option value arrived with escaping already
+    # unwrapped. Examining sendbackup debug log shows the value apparently
+    # passed to sendbackup in an escaped form, but unescaped in the section
+    # of the log file that shows "sendbackup: running ..." with the arguments
+    # logged one by one. Looks like sendbackup does the unwrapping and uses
+    # exec directly; todo: check the code to confirm.
+
+    # ... yes, that's just what sendbackup does.
+
+    my $script = $class->new($execute_where, \%opthash);
+
+    $script->do($execute_where);
+}
+
+=head2 C<new>
+
+    $class->new(\%opthash)
+
+A typical application need not call this; it is called by C<run> after the
+command line options have been declared and the command line has been parsed.
+The hash reference contains option values as stored by C<GetOptions>. A certain
+convention is assumed: if there is an option/property named I<o>, its value
+will be stored in I<opthash> with key exactly I<o>, in exactly the way
+C<GetOptions> normally would, I<unless> the option-declaring method had planted
+a code reference there in order to more strictly validate the option. In that
+case, of course I<$opthash{o}> is the code reference, and the final value will
+be stored with key C<opt_>I<o> instead. Because of that convention, entries in
+I<opthash> with an C<opt_> prefix will otherwise be ignored; avoid declaring
+options/properties whose actual names start with C<opt_>.
+
+=cut
+
+sub new {
+    my ( $class, $execute_where, $refopthash ) = @_;
+    my %options = ();
+    for ( my ($k, $v) ; ($k, $v) = each %{$refopthash} ; ) {
+	next if $k =~ /^opt_/;
+	if ( "CODE" ne ref $v ) {
+	    $options{$k} = $v;
+	}
+	else {
+	    $options{$k} = $refopthash->{"opt_".$k}
+	}
+    }
+    my $self = $class->SUPER::new($execute_where, $options{'config'});
+    $self->{'options'} = \%options;
+    return $self;
+}
+
+=head1 CLASS METHOD FOR DECLARING ALLOWED OPTIONS / PROPERTIES
+
+=head2 C<declare_options>
+
+    declare_options(\%opthash, \@optspecs)
+
+This is a class method that is passed two references: a hash reference
+I<\%opthash> and a list reference I<\@optspecs>. It should push onto
+I<\@optspecs> the declarations of whatever options are valid for the
+script, using the syntax described in L<Getopt::Long>.
+It does not need to touch I<\%opthash>, but may store a code reference at the
+name of any option, to apply stricter validation when the option is parsed.
+In that case, the code reference should ultimately store the validated value
+into I<\%opthash> at a key derived by prefixing C<opt_> to the option name.
+
+=cut
+
+sub declare_options {
+    my ( $class, $refopthash, $refoptspecs ) = @_;
+    push @$refoptspecs,
+        ( 'config=s', 'host=s', 'disk=s', 'device=s', 'level=i@',
+	  'execute-where=s' );
+}
+
+1;

--- a/perl/Makefile.am
+++ b/perl/Makefile.am
@@ -715,13 +715,17 @@ EXTRA_DIST += Amanda/Application.swg Amanda/Application.pm Amanda/Application.po
 Amanda_DATA += Amanda/Script.pm
 EXTRA_DIST += Amanda/Script.pm
 
+# PACKAGE: Amanda::Script::*
+Amanda_DATA += Amanda/Script/Abstract.pm
+EXTRA_DIST += Amanda/Script/Abstract.pm
+
 if WANT_CLIENT
 # PACKAGE: Amanda::Application::*
 AmandaApplicationdir = $(amperldir)/Amanda/Application
-AmandaApplication_DATA = Amanda/Application/Zfs.pm
+AmandaApplication_DATA = Amanda/Application/Abstract.pm Amanda/Application/Zfs.pm
 PM_FILES += $(AmandaApplication_DATA)
 endif
-EXTRA_DIST += Amanda/Application/Zfs.pm
+EXTRA_DIST += Amanda/Application/Abstract.pm Amanda/Application/Zfs.pm
 
 ../genversion.h Amanda/Constants.pm.in: $(top_builddir)/config.status Amanda/Constants.pm.in.src
 	-rm -f ../common-src/genversion.h ../common-src/genversion.h.new


### PR DESCRIPTION
# Application and script abstract classes

The goal of this work is to widen the population that can easily write reliable new Amanda applications and scripts to support specialized backup needs. The [topmost section][apptasks] of the Amanda wiki Development Tasks list presents several useful applications that could be added to Amanda, and that list has been [unchanged for seven years][taskhist].

[apptasks]: http://wiki.zmanda.com/index.php/Tasks#Applications
[taskhist]: http://wiki.zmanda.com/index.php?title=Tasks&action=history

Arguably, the slow pace of new application and script development relates to the level at which the current [Application API][aapi] and [Script API][sapi] are defined. Those documents spell out the arguments and file descriptors passed to an application or script process, and the concrete syntax of messages to be exchanged.

[aapi]: http://wiki.zmanda.com/index.php/Application_API/Operations
[sapi]: http://wiki.zmanda.com/index.php/Script_API

Specification at that level has the advantage of being language-agnostic: an Amanda application or script could in theory be written in any language, as long as it consumes and produces the needed arguments and messages properly. Its disadvantage is a level of detail far removed from the practical problem a would-be application or script writer wants to solve. It tends to narrow the potential population of Amanda application or script authors: rather than including any Amanda user with a problem to solve and an idea how to do so, it realistically demands some expertise in IPC protocols and enough Amanda internals knowledge to fill in the actual behavior behind some of the syntax. (The many [amanda-hackers messages exchanged][ahmsg] during this work illustrate some of the traps for the unwary.)

[ahmsg]: http://marc.info/?l=amanda-hackers&s=coding+an+Application+in+perl

While language-agnostic in theory, applications and scripts for Amanda are likely to be written in perl, given its heavy use in Amanda proper. Specifically, they are likely to be object-oriented perl code that extends one of the base classes [Amanda::Application][ama] or [Amanda::Script][ams]. They do inherit a small amount of common functionality from their base classes, but not nearly as much as they could. Inheriting classes are still on their own, for example, to produce and consume the API-defined IPC messages, ensuring valid syntax.

[ama]: http://wiki.zmanda.com/pod/3.4.5/Amanda/Application.html
[ams]: http://wiki.zmanda.com/pod/3.4.5/Amanda/Script.html

Less-thin abstract base classes could encapsulate much more of that common work, and present a traditional, object-oriented API where new application or script code may override just a few key methods and rely on default behavior wherever customization is not needed. That can make applications and scripts much faster to develop, and easier to review for correctness. At the same time, it simplifies future evolution of the IPC messages, something that would be increasingly impractical if a growing set of scripts and applications all contain duplicated code with those details baked in, but is simple with methods inherited from one central place.

This work, therefore, introduces the new abstract classes `Amanda::Application::Abstract` and `Amanda::Script::Abstract`. To stay compatible with existing applications and scripts, this work makes no changes to the existing classes [Amanda::Application][ama] and [Amanda::Script][ams]. Those classes are simply inherited by these new base classes, which are implemented in pure perl and provide a richer object-oriented API to applications and scripts that choose to inherit from them.

This layering also means that if it is ever desired to write an Amanda application or script in another scripting language than perl, these two pure-perl classes are essentially what could be translated to provide an "Amanda application/script API binding" for that language.

## Included sample applications / scripts

Included here are four new applications to show the simplicity of development: `amooraw` (merely `amraw` redone in OO style), `amgrowingfile` (useful for a single large file known to only monotonically grow; can do incremental levels), `amgrowingzip` (like `amgrowingfile` but for a ZIP archive), and `amopaquetree` (backup of a directory/file tree where restoration of individual files won't be needed, but with fine-grained incremental backup down to only changed regions within files, rather than entire files that may contain small changes).

The `amopaquetree` application is also one that might itself be used as a base class for a specialized application applying the same opaque-tree, fine-grained-increments approach to a specific database management system, for example.

Four new scripts are also provided: `am389bak` for taking a consistent snapshot of a 389 Directory Server instance before estimate or backup, `amsvnmakehotcopy` to do the same for a Subversion repository, `amlvmsnapshot` to allow backing up from a snapshot of a filesystem using LVM, and `amlibvirtfsfreeze` to freeze and thaw filesystems in a libvirt-supported guest VM, so the host filesystem can be snapshotted for backup at a moment when the guest image files are consistent.

These four scripts, especially, should be considered experimental or demo quality at this stage. They do little error checking of external commands they execute (though they work fine when nothing goes wrong), and, to be useful in most real environments, they are likely to need short C-language setuid wrappers to be written for those few external commands, and such wrappers are not included in this commit. A configurable, secure, general-purpose permission-granting wrapper would greatly simplify development of scripts like these, but a design for that remains future work.

## Future work

### Elevated permissions

As mentioned above, a design for a general-purpose and securely configurable way to grant elevated permission to specific actions executed from selected applications or scripts (as opposed to having to write some C analog of `runtar` for each needed case) could be a challenging design problem, but one that would greatly simplify application/script development for real environments.

### I/O involving child processes

The example applications and scripts presented here do less than they ought in the way of capturing standard and error output from child processes they execute, interpreting and responding appropriately, or passing modified messages upstream to Amanda. Fully robust implementations would include that, ideally without adding such complexity it obscures the outlines of the code.

Doing such work at the low level of, say, perl's [open3][] is too longwinded to be ideal. Experienced Amanda developers may prefer to work with the features of [Amanda::MainLoop][aml], already familiar from other parts of the guts of Amanda. For other potential application or script developers, who may not have deep Amanda hacking experience but will know perl, the familiarity and clear, intuitive syntax of perl's [IPC::Run][ipcr] might be more appealing.

[open3]: http://perldoc.perl.org/IPC/Open3.html
[aml]: http://wiki.zmanda.com/pod/3.4.5/Amanda/MainLoop.html
[ipcr]: http://search.cpan.org/~toddr/IPC-Run-0.96/lib/IPC/Run.pm

`IPC::Run` is a CPAN module that need not be present on every system with perl, and might not be a suitable dependency for Amanda core. Because of its functionality and appealing syntax, though, it might be something that specialized applications or scripts might rely on if the author prefers. Such applications or scripts would need to avoid breaking [make check][mck], and return a suitable error to [amcheck][], on systems where the module is not present. It would be simple to provide some stub support in Amanda::Application::Abstract and Amanda::Script::Abstract to simplify that.

[mck]: http://wiki.zmanda.com/index.php/Testing#Make_Check
[amcheck]: http://wiki.zmanda.com/man/3.4.5/amcheck.8.html 