### PR TITLE
Let auth 'local' match the local box however named.

### DIFF
--- a/common-src/local-security.c
+++ b/common-src/local-security.c
@@ -56,6 +56,8 @@ static void local_connect(const char *, char *(*)(char *, void *),
 
 static char *local_get_authenticated_peer_name_hostname(security_handle_t *hdl);
 
+static gboolean is_local(const char *);
+
 /*
  * This is our interface to the outside world.
  */
@@ -114,7 +116,6 @@ local_connect(
     struct sec_handle *rh;
     char *amandad_path=NULL;
     char *client_username=NULL;
-    char myhostname[MAX_HOSTNAME_LENGTH+1];
 
     assert(fn != NULL);
     assert(hostname != NULL);
@@ -129,15 +130,7 @@ local_connect(
     rh->ev_timeout = NULL;
     rh->rc = NULL;
 
-    if (gethostname(myhostname, MAX_HOSTNAME_LENGTH) == -1) {
-	security_seterror(&rh->sech, _("gethostname failed"));
-	(*fn)(arg, &rh->sech, S_ERROR);
-	return;
-    }
-    myhostname[sizeof(myhostname)-1] = '\0';
-
-    if (!g_str_equal(hostname, myhostname) &&
-	match("^localhost(\\.localdomain)?$", hostname) == 0) {
+    if (!is_local(hostname)) {
 	security_seterror(&rh->sech,
 	    _("%s: is not local"), hostname);
 	(*fn)(arg, &rh->sech, S_ERROR);
@@ -309,4 +302,50 @@ local_get_authenticated_peer_name_hostname(
     amfree(server_hostname);
     return g_strdup("localhost");
 
+}
+
+/*
+ * Recognize whether hostname refers to this host, regardless of how it is
+ * spelled, capitalized, abbreviated or fully qualified, etc.
+ *
+ * If there exists any address for hostname to which a socket can be bound,
+ * return TRUE.
+ */
+static gboolean
+is_local(const char *hostname)
+{
+    struct addrinfo *addrs;
+    struct addrinfo *a;
+    int rslt;
+    int s;
+    gboolean verdict = FALSE;
+
+    rslt = resolve_hostname(hostname, 0, &addrs, NULL);
+    if (0 != rslt) {
+        dbprintf("Unresolved hostname %s assumed nonlocal: %s\n",
+	         hostname, gai_strerror(rslt));
+        return verdict;
+    }
+    /* Beyond this point, addrs must be freed */
+
+    /* Invariant: s is not an open socket */
+    for ( a = addrs ; NULL != a ; a = a->ai_next ) {
+        s = socket(a->ai_family, a->ai_socktype, a->ai_protocol);
+	if ( -1 == s )
+	    continue;
+	rslt = bind(s, a->ai_addr, a->ai_addrlen);
+	if ( 0 == rslt ) {
+	    close(s);
+	    verdict = TRUE;
+	    break;
+	}
+	if ( EADDRNOTAVAIL != errno ) {
+	    dbprintf("strange bind() result %s\n", strerror(errno));
+	}
+	close(s);
+    }
+    /* s is not open here */
+
+    freeaddrinfo(addrs);
+    return verdict;
 }

--- a/man/xml-source/amanda-auth.7.xml
+++ b/man/xml-source/amanda-auth.7.xml
@@ -446,7 +446,8 @@ DNS.</para>
 <refsect1><title>LOCAL COMMUNICATION</title>
 <para>The Amanda server communicates with the client internally versus over the network, ie. the client is also the server.</para>
 <para>This is the only method that requires no authentication as it is clearly not needed.</para>
-<para>The authenticated peer hostname for this authentication is always "localhost".</para>
+<para>The authenticated peer hostname for this authentication will be as reported by <emphasis remap='B'>gethostname</emphasis> if that succeeds, or the fixed string <emphasis remap='I'>localhost</emphasis> otherwise.</para>
+<para>This method requires the host name in the DLE to be one that refers to this host. Any name for which <emphasis remap='B'>gataddrinfo</emphasis> is able to return at least one address usable as the local end of a socket will work.</para>
 </refsect1>
 
 <refsect1><title>RSH COMMUNICATION AND AUTHENTICATION</title>


### PR DESCRIPTION
It was not clearly documented what hostname must be used in a DLE for auth "local" to work, and the test relied on string comparison, which could report the host as "not local" depending on how the name was abbreviated or fully qualified, capitalized, aliased, etc.

Instead, allow the DLE to use any hostname that can be confirmed to refer to this host. As long as `getaddrinfo` finds at least one address for it that the local end of a socket can be bound to, it will work.

Clarify that in `amanda-auth(7)`, and also clarify that the "authenticated peer hostname" will be as reported by `gethostname()` whenever that succeeds, or `localhost` if it does not. (This has been true since 3.3.0 but the documentation didn't catch up.)

Discussion: http://marc.info/?t=149202030200002 