### PR TITLE
Honor DIRECTORY property more consistently.

### DIFF
--- a/application-src/ambsdtar.c
+++ b/application-src/ambsdtar.c
@@ -128,7 +128,7 @@ static void ambsdtar_index(application_argument_t *argument);
 static void ambsdtar_build_exinclude(dle_t *dle,
 				     int *nb_exclude, char **file_exclude,
 				     int *nb_include, char **file_include,
-				     messagelist_t *mlist);
+				     char *dirname, messagelist_t *mlist);
 static char *ambsdtar_get_timestamps(application_argument_t *argument,
 				     int level,
 				     FILE *mesgstream, int command);
@@ -676,7 +676,8 @@ ambsdtar_selfcheck(
 			"device", argument->dle.device,
 			"hostname", argument->host)));
 
-    ambsdtar_build_exinclude(&argument->dle, NULL, NULL, NULL, NULL, &mlist);
+    ambsdtar_build_exinclude(&argument->dle, NULL, NULL, NULL, NULL,
+                             argument->dle.device, &mlist);
     for (mesglist = mlist; mesglist != NULL; mesglist = mesglist->next){
 	message_t *message = mesglist->data;
 	if (message_get_severity(message) > MSG_INFO)
@@ -854,7 +855,7 @@ ambsdtar_estimate(
 	}
 	ambsdtar_build_exinclude(&argument->dle,
 				 &nb_exclude, &file_exclude,
-				 &nb_include, &file_include, &mlist);
+				 &nb_include, &file_include, dirname, &mlist);
 	for (mesglist = mlist; mesglist != NULL; mesglist = mesglist->next){
 	    message_t *message = mesglist->data;
 	    if (message_get_severity(message) > MSG_INFO)
@@ -1979,6 +1980,7 @@ ambsdtar_build_exinclude(
     char  **file_exclude,
     int    *nb_include,
     char  **file_include,
+    char   *dirname,
     messagelist_t *mlist)
 {
     int n_exclude = 0;
@@ -1992,7 +1994,7 @@ ambsdtar_build_exinclude(
     if (dle->include_list) n_include += dle->include_list->nb_element;
 
     if (n_exclude > 0) exclude = build_exclude(dle, mlist);
-    if (n_include > 0) include = build_include(dle, mlist);
+    if (n_include > 0) include = build_include(dle, dirname, mlist);
 
     if (nb_exclude)
 	*nb_exclude = n_exclude;
@@ -2178,15 +2180,15 @@ ambsdtar_build_argv(
     GPtrArray *argv_ptr = g_ptr_array_new();
     GSList    *copt;
 
-    ambsdtar_build_exinclude(&argument->dle,
-			     &nb_exclude, file_exclude,
-			     &nb_include, file_include, mlist);
-
     if (bsdtar_directory) {
 	dirname = bsdtar_directory;
     } else {
 	dirname = argument->dle.device;
     }
+
+    ambsdtar_build_exinclude(&argument->dle,
+			     &nb_exclude, file_exclude,
+			     &nb_include, file_include, dirname, mlist);
 
     g_ptr_array_add(argv_ptr, g_strdup(bsdtar_realpath));
 

--- a/application-src/amgtar.c
+++ b/application-src/amgtar.c
@@ -150,7 +150,7 @@ static void amgtar_index(application_argument_t *argument);
 static void amgtar_build_exinclude(dle_t *dle,
 				   int *nb_exclude, char **file_exclude,
 				   int *nb_include, char **file_includei,
-				   messagelist_t *mlist);
+				   char *dirname, messagelist_t *mlist);
 static char *amgtar_get_incrname(application_argument_t *argument, int level,
 				 FILE *mesgstream, int command);
 static void check_no_check_device(void);
@@ -961,7 +961,8 @@ amgtar_selfcheck(
 			"disk", argument->dle.disk,
 			"device", argument->dle.device,
 			"hostname", argument->host)));
-    amgtar_build_exinclude(&argument->dle, NULL, NULL, NULL, NULL, &mlist);
+    amgtar_build_exinclude(&argument->dle, NULL, NULL, NULL, NULL,
+                           argument->dle.device, &mlist);
     for (mesglist = mlist; mesglist != NULL; mesglist = mesglist->next){
 	message_t *message = mesglist->data;
 	if (message_get_severity(message) > MSG_INFO)
@@ -1120,7 +1121,7 @@ amgtar_estimate(
 
 	amgtar_build_exinclude(&argument->dle,
 			       &nb_exclude, &file_exclude,
-			       &nb_include, &file_include, &mlist);
+			       &nb_include, &file_include, dirname, &mlist);
 	for (mesglist = mlist; mesglist != NULL; mesglist = mesglist->next){
 	    message_t *message = mesglist->data;
 	    if (message_get_severity(message) > MSG_INFO)
@@ -2036,6 +2037,7 @@ amgtar_build_exinclude(
     char  **file_exclude,
     int    *nb_include,
     char  **file_include,
+    char   *dirname,
     messagelist_t *mlist)
 {
     int n_exclude = 0;
@@ -2049,7 +2051,7 @@ amgtar_build_exinclude(
     if (dle->include_list) n_include += dle->include_list->nb_element;
 
     if (n_exclude > 0) exclude = build_exclude(dle, mlist);
-    if (n_include > 0) include = build_include(dle, mlist);
+    if (n_include > 0) include = build_include(dle, dirname, mlist);
 
     if (nb_exclude)
 	*nb_exclude = n_exclude;
@@ -2279,15 +2281,16 @@ GPtrArray *amgtar_build_argv(
     GSList    *copt;
 
     check_no_check_device();
-    amgtar_build_exinclude(&argument->dle,
-			   &nb_exclude, file_exclude,
-			   &nb_include, file_include, mlist);
 
     if (gnutar_directory) {
 	dirname = gnutar_directory;
     } else {
 	dirname = argument->dle.device;
     }
+
+    amgtar_build_exinclude(&argument->dle,
+			   &nb_exclude, file_exclude,
+			   &nb_include, file_include, dirname, mlist);
 
     g_ptr_array_add(argv_ptr, g_strdup(gnutar_realpath));
 

--- a/client-src/client_util.c
+++ b/client-src/client_util.c
@@ -364,6 +364,7 @@ build_exclude(
 char *
 build_include(
     dle_t         *dle,
+    char const    *dirname,
     messagelist_t *mlist)
 {
     char *filename;
@@ -385,7 +386,7 @@ build_include(
 	    if (dle->include_file) {
 		for (incl = dle->include_file->first; incl != NULL;
 		    incl = incl->next) {
-		    nb_exp += add_include(dle->disk, dle->device, file_include,
+		    nb_exp += add_include(dle->disk, dirname, file_include,
 				  incl->name, dle->include_optional, mlist);
 		}
 	    }
@@ -400,7 +401,7 @@ build_include(
 				amfree(ainc);
 				continue;
 			    }
-			    nb_exp += add_include(dle->disk, dle->device,
+			    nb_exp += add_include(dle->disk, dirname,
 						  file_include, ainc,
 						  dle->include_optional, mlist);
 			    amfree(ainc);

--- a/client-src/client_util.h
+++ b/client-src/client_util.h
@@ -112,7 +112,7 @@ typedef struct regex_s {
 #define AM_ERROR_RE(re)		{(re), __LINE__, 0, 0, DMP_ERROR}
 
 char *build_exclude(dle_t *dle, messagelist_t *mlist);
-char *build_include(dle_t *dle, messagelist_t *mlist);
+char *build_include(dle_t *dle, char const *dirname, messagelist_t *mlist);
 void parse_options(char *str,
 		   dle_t *dle,
 		   am_feature_t *features,

--- a/client-src/selfcheck.c
+++ b/client-src/selfcheck.c
@@ -494,7 +494,8 @@ check_options(
 	    if (dle->include_list) nb_include += dle->include_list->nb_element;
 
 	    if (nb_exclude > 0) file_exclude = build_exclude(dle, &mlist);
-	    if (nb_include > 0) file_include = build_include(dle, &mlist);
+	    if (nb_include > 0)
+		file_include = build_include(dle, dle->device, &mlist);
 	    for (mesglist = mlist; mesglist != NULL; mesglist = mesglist->next){
 		message_t *message = mesglist->data;
 		if (message_get_severity(message) > MSG_INFO)

--- a/client-src/sendbackup-gnutar.c
+++ b/client-src/sendbackup-gnutar.c
@@ -573,7 +573,7 @@ start_backup(
 	if (dle->include_list) nb_include+=dle->include_list->nb_element;
 
 	if (nb_exclude > 0) file_exclude = build_exclude(dle, &mlist);
-	if (nb_include > 0) file_include = build_include(dle, &mlist);
+	if (nb_include > 0) file_include = build_include(dle, dirname, &mlist);
 	g_slist_free(mlist); // MUST also free the message
 
 	cmd = g_strjoin(NULL, amlibexecdir, "/", "runtar", NULL);

--- a/client-src/sendsize.c
+++ b/client-src/sendsize.c
@@ -1084,7 +1084,7 @@ generic_calc_estimates(
     if (nb_exclude > 0)
 	file_exclude = build_exclude(est->dle, &mlist);
     if (nb_include > 0)
-	file_include = build_include(est->dle, &mlist);
+	file_include = build_include(est->dle, est->dirname, &mlist);
     g_slist_free(mlist); // MUST also free the message
 
     if(file_exclude) {
@@ -2136,6 +2136,8 @@ getsize_gnutar(
 	return -2; /* planner will not even consider this level */
     }
 
+    dirname = amname_to_dirname(dle->device);
+
     qdisk = quote_string(dle->disk);
     if(dle->exclude_file) nb_exclude += dle->exclude_file->nb_element;
     if(dle->exclude_list) nb_exclude += dle->exclude_list->nb_element;
@@ -2143,7 +2145,7 @@ getsize_gnutar(
     if(dle->include_list) nb_include += dle->include_list->nb_element;
 
     if(nb_exclude > 0) file_exclude = build_exclude(dle, &mlist);
-    if(nb_include > 0) file_include = build_include(dle, &mlist);
+    if(nb_include > 0) file_include = build_include(dle, dirname, &mlist);
     g_slist_free(mlist); // MUST also free the message
 
     gnutar_list_dir = getconf_str(CNF_GNUTAR_LIST_DIR);
@@ -2245,8 +2247,6 @@ getsize_gnutar(
 		"%04d-%02d-%02d %2d:%02d:%02d GMT",
 		gmtm->tm_year + 1900, gmtm->tm_mon+1, gmtm->tm_mday,
 		gmtm->tm_hour, gmtm->tm_min, gmtm->tm_sec);
-
-    dirname = amname_to_dirname(dle->device);
 
     cmd = g_strjoin(NULL, amlibexecdir, "/", "runtar", NULL);
     g_ptr_array_add(argv_ptr, g_strdup("runtar"));


### PR DESCRIPTION
Working on a new script that emits a DIRECTORY property so the application knows where to look, I was surprised to get "Failed to chdir(...)" messages from the application still trying to refer to the old (wrong) value of DEVICE. It turns out `build_include` was not being passed the final `dirname`.

This patch fudges on some cases, like selfchecks, where I wasn't sure if the property was available. I needed it to work tonight, so there may be some signs of haste here, but it got my backups going so I could come home.