### PR TITLE
3 5

### DIFF
--- a/application-src/amgtar.c
+++ b/application-src/amgtar.c
@@ -820,14 +820,33 @@ static char *validate_command_options(
     for (copt = argument->command_options; copt != NULL; copt = copt->next) {
 	char *opt = (char *)copt->data;
 
-	if (g_str_has_prefix(opt, "--rsh-command") ||
-	    g_str_has_prefix(opt,"--to-command") ||
-	    g_str_has_prefix(opt,"--info-script") ||
-	    g_str_has_prefix(opt,"--new-volume-script") ||
-	    g_str_has_prefix(opt,"--rmt-command") ||
-	    g_str_has_prefix(opt,"--use-compress-program")) {
-	    return opt;
-	}
+	if (g_str_has_prefix(opt,"--create") ||
+		g_str_has_prefix(opt,"--totals") ||
+		g_str_has_prefix(opt,"--dereference") ||
+		g_str_has_prefix(opt,"--no-recursion") ||
+		g_str_has_prefix(opt,"--one-file-system") ||
+		g_str_has_prefix(opt,"--incremental") ||
+		g_str_has_prefix(opt,"--atime-preserve") ||
+		g_str_has_prefix(opt,"--sparse") ||
+		g_str_has_prefix(opt,"--ignore-failed-read") ||
+		g_str_has_prefix(opt,"--numeric-owner") ||
+		g_str_has_prefix(opt,"--verbose") ||
+		g_str_has_prefix(opt,"--blocking-factor") ||
+		g_str_has_prefix(opt,"--file") ||
+		g_str_has_prefix(opt,"--directory") ||
+		g_str_has_prefix(opt,"--exclude") ||
+		g_str_has_prefix(opt,"--transform") ||
+		g_str_has_prefix(opt,"--listed-incremental") ||
+		g_str_has_prefix(opt,"--newer") ||
+		g_str_has_prefix(opt,"--exclude-from") ||
+		g_str_has_prefix(opt,"--files-from")) {
+			// All the above mentioned options are allowed.
+			continue;
+		}
+		else {
+			// This function return non-null value if one of the not allowed option is given.
+			return opt;
+		}
     }
 
     return NULL;

--- a/application-src/amstar.c
+++ b/application-src/amstar.c
@@ -619,8 +619,9 @@ static char *validate_command_options(
     for (copt = argument->command_options; copt != NULL; copt = copt->next) {
 	char *opt = (char *)copt->data;
 
-	if (g_str_has_prefix(opt, "--compress-command") ||
-	    g_str_has_prefix(opt, "new-volume-script")) {
+	if (g_str_has_prefix(opt, "new-volume-script") ||
+		g_str_has_prefix(opt, "-new-volume-script") ||
+		g_str_has_prefix(opt, "--new-volume-script")) {
 	   return opt;
 	}
     }

--- a/application-src/amstar.c
+++ b/application-src/amstar.c
@@ -619,7 +619,8 @@ static char *validate_command_options(
     for (copt = argument->command_options; copt != NULL; copt = copt->next) {
 	char *opt = (char *)copt->data;
 
-	if (g_str_has_prefix(opt, "--compress-command")) {
+	if (g_str_has_prefix(opt, "--compress-command") ||
+	    g_str_has_prefix(opt, "new-volume-script")) {
 	   return opt;
 	}
     }

--- a/client-src/rundump.c
+++ b/client-src/rundump.c
@@ -69,6 +69,8 @@ main(
     GPtrArray *array = g_ptr_array_new();
     gchar **strings;
     char  **env;
+    int good_option;
+	char *prgName;
 #endif /* ERRMSG */
 
     glib_init();
@@ -176,11 +178,55 @@ main(
     /*
      * Build the array
      */
-
-    g_ptr_array_add(array, g_strdup(dump_program));
-
-    for (i = 1; argv[i]; i++)
-        g_ptr_array_add(array, quote_string(argv[i]));
+	 
+	g_ptr_array_add(array, g_strdup(dump_program));
+	
+	// No need to deallocate "prgName", as strrchr is not returning newly allocated memory
+	// but just returning an offset to the string.
+	prgName = g_strrstr(dump_program, "/");
+	good_option = 0;
+    for (i = 1; argv[i]; i++) {
+    	if (good_option <= 0) {
+			if ( prgName != NULL && g_strcmp0(prgName, "/dump") == 0 ) {
+				if ( g_str_has_prefix(argv[i], "-a") || g_str_has_prefix(argv[i], "-A") || g_str_has_prefix(argv[i], "-b") || 
+				g_str_has_prefix(argv[i], "-B") || g_str_has_prefix(argv[i], "-c") || g_str_has_prefix(argv[i], "-d") || 
+				g_str_has_prefix(argv[i], "-D") || g_str_has_prefix(argv[i], "-e") || g_str_has_prefix(argv[i], "-f") || 
+				g_str_has_prefix(argv[i], "-h") || g_str_has_prefix(argv[i], "-I") || g_str_has_prefix(argv[i], "-j") || 
+				g_str_has_prefix(argv[i], "-k") || g_str_has_prefix(argv[i], "-L") || g_str_has_prefix(argv[i], "-m") || 
+				g_str_has_prefix(argv[i], "-M") || g_str_has_prefix(argv[i], "-n") || g_str_has_prefix(argv[i], "-q") || 
+				g_str_has_prefix(argv[i], "-Q") || g_str_has_prefix(argv[i], "-s") || g_str_has_prefix(argv[i], "-S") || 
+				g_str_has_prefix(argv[i], "-T") || g_str_has_prefix(argv[i], "-u") || g_str_has_prefix(argv[i], "-v") || 
+				g_str_has_prefix(argv[i], "-W") || g_str_has_prefix(argv[i], "-w") || g_str_has_prefix(argv[i], "-y") || 
+				g_str_has_prefix(argv[i], "-z") || 
+				(g_str_has_prefix(argv[i], "-") && g_ascii_isdigit(argv[i][1]) && (strlen(argv[i]) == 2)) || 
+				argv[i][0] != '-' ) {
+					good_option++;
+				}
+			}
+			else if ( prgName != NULL && g_strcmp0(prgName, "/xfsdump") == 0) {
+				if ( g_str_has_prefix(argv[i], "-a") || g_str_has_prefix(argv[i], "-b") || g_str_has_prefix(argv[i], "-d") || 
+				g_str_has_prefix(argv[i], "-e") || g_str_has_prefix(argv[i], "-f") || g_str_has_prefix(argv[i], "-l") ||
+				g_str_has_prefix(argv[i], "-m") || g_str_has_prefix(argv[i], "-o") || g_str_has_prefix(argv[i], "-p") || 
+				g_str_has_prefix(argv[i], "-q") || g_str_has_prefix(argv[i], "-s") || g_str_has_prefix(argv[i], "-t") || 
+				g_str_has_prefix(argv[i], "-v") || g_str_has_prefix(argv[i], "-z") || g_str_has_prefix(argv[i], "-A") || 
+				g_str_has_prefix(argv[i], "-B") || g_str_has_prefix(argv[i], "-D") || g_str_has_prefix(argv[i], "-I") || 
+				g_str_has_prefix(argv[i], "-J") || g_str_has_prefix(argv[i], "-L") || g_str_has_prefix(argv[i], "-M") || 
+				g_str_has_prefix(argv[i], "-R") || g_str_has_prefix(argv[i], "-T") || g_str_has_prefix(argv[i], "-F") ||
+				(g_str_has_prefix(argv[i], "-") && (strlen(argv[i]) == 1)) || argv[i][0] != '-' ) {
+					good_option++;
+				}				
+			}
+			else {
+				good_option = 0;
+			}
+			
+			if (good_option <= 0) {
+				error ("error [%s invalid option: %s]", get_pname(), argv[i]);
+			}
+			good_option--;
+    	}
+		g_ptr_array_add(array, quote_string(argv[i]));
+    }
 
     g_ptr_array_add(array, NULL);
     strings = (gchar **)g_ptr_array_free(array, FALSE);

--- a/client-src/rundump.c
+++ b/client-src/rundump.c
@@ -40,8 +40,8 @@
 #include "conffile.h"
 
 int main(int argc, char **argv);
-static int validate_dump_option(int argc, char ** argv);
-static int validate_xfsdump_options(int argc, char ** argv);
+static void validate_dump_option(int argc, char ** argv);
+static void validate_xfsdump_options(int argc, char ** argv);
 
 #if defined(VDUMP) || defined(XFSDUMP)
 #  undef USE_RUNDUMP
@@ -71,7 +71,6 @@ main(
     GPtrArray *array = g_ptr_array_new();
     gchar **strings;
     char  **env;
-	char *prgName;
 #endif /* ERRMSG */
 
     glib_init();
@@ -162,15 +161,18 @@ main(
 #endif
 
 #if defined(DUMP)
-        dump_program = DUMP;
+    dump_program = DUMP;
+    validate_dump_option(argc, argv);
 #else
 # if defined(XFSDUMP)
-        dump_program = XFSDUMP;
+    dump_program = XFSDUMP;
+    validate_xfsdump_options(argc, argv);
 # else
 #  if defined(VXDUMP)
 	dump_program = VXDUMP;
 #  else
-        dump_program = "dump";
+    dump_program = "dump";
+	validate_dump_option(argc, argv);
 #  endif
 # endif
 #endif
@@ -180,27 +182,6 @@ main(
      */	 
 	g_ptr_array_add(array, g_strdup(dump_program));
 	
-	// No need to deallocate "prgName", as strrchr is not returning newly allocated memory
-	// but just returning an offset to the string.
-	prgName = g_strrstr(dump_program, "/");
-	if (prgName == NULL)
-	{
-		prgName = dump_program;
-	}
-	else
-	{
-		prgName++;
-	}
-	if (g_strcmp0(prgName, "dump") == 0) {
-		if (validate_dump_option(argc, argv) != 0) {
-			error(" ");
-		}
-	}
-	else if (g_strcmp0(prgName, "xfsdump") == 0) {
-		if (validate_xfsdump_options(argc, argv) != 0) {
-			error(" ");
-		}
-	}
     for (i = 1; argv[i]; i++) {
 		g_ptr_array_add(array, quote_string(argv[i]));
     }
@@ -227,16 +208,20 @@ main(
 #endif								/* } */
 }
 
-int validate_dump_option(int argc, char ** argv)
+void validate_dump_option(int argc, char ** argv)
 {
 	int c;
-	while ((c = getopt(argc, argv, "0123456789ab:cd:e:f:h:j:kmnqs:uvwyz:A:B:D:I:L:MQ:ST:W")) != -1) 
+	int numargs = argc;
+	while (numargs > 0)
 	{
+		c = getopt(argc, argv, "0123456789ab:cd:e:f:h:j:kmnqs:uvwyz:A:B:D:I:L:MQ:ST:W");
 		switch (c) {
+			case -1:
+				optind++;
+			break;
 			case '?':
 				//option is not valid
-				printf ("error [%s invalid option: %c]\n", get_pname(), c);
-				return 1;
+				error("error [%s invalid option: %s]\n", get_pname(), argv[optind-1]);
 			break;
 			// All this options takes another argument
 			case 'b':
@@ -257,8 +242,7 @@ int validate_dump_option(int argc, char ** argv)
 			{
 				// get optarg and check it against NULL. If it is null, then return error.
 				if (optarg == NULL) {
-					printf ("error [%s additional parameter is missing for option: %c]\n", get_pname(), c);
-					return 1;
+					error("error [%s additional parameter is missing for option: %c]\n", get_pname(), c);
 				}
 				break;
 			}
@@ -289,23 +273,26 @@ int validate_dump_option(int argc, char ** argv)
 				break;
 			}
 			default:
-				printf ("error [%s invalid option: %c]\n", get_pname(), c);
-				return 1;
+				error("error [%s invalid option: %c]\n", get_pname(), c);
 			break;
 		}
+		numargs--;
 	}
-	return 0;
 }
-int validate_xfsdump_options(int argc, char ** argv)
+void validate_xfsdump_options(int argc, char ** argv)
 {
 	int c;
-	while ((c = getopt(argc, argv, "ab:d:ef:l:mop:qs:t:v:z:AB:DFI:JL:M:RT")) != -1)
+	int numargs = argc;
+	while (numargs > 0)
 	{
+		c = getopt(argc, argv, "ab:d:ef:l:mop:qs:t:v:z:AB:DFI:JL:M:RT");
 		switch (c) {
+			case -1:
+				optind++;
+			break;
 			case '?':
 				//option is not valid
-				printf ("error [%s invalid option: %c]\n", get_pname(), c);
-				return 1;
+				error("error [%s invalid option: %s]\n", get_pname(), argv[optind-1]);
 			break;
 			// All this options takes another argument
 			case 'b':
@@ -324,8 +311,7 @@ int validate_xfsdump_options(int argc, char ** argv)
 			{
 				// get optarg and check it against NULL. If it is null, then return error.
 				if (optarg == NULL) {
-					printf ("error [%s additional parameter is missing for option: %c]\n", get_pname(), c);
-					return 1;
+					error("error [%s additional parameter is missing for option: %c]\n", get_pname(), c);
 				}
 				break;
 			}
@@ -344,10 +330,9 @@ int validate_xfsdump_options(int argc, char ** argv)
 				break;
 			}
 			default:
-				printf ("error [%s invalid option: %c]\n", get_pname(), c);
-				return 1;
+				error("error [%s invalid option: %c]\n", get_pname(), c);
 			break;
 		}
+		numargs--;
 	}
-	return 0;
 }


### PR DESCRIPTION
application-src/amgtar.c - Filter gnutar arguments using WHITELIST approach
application-src/amstar.c - Filter star arguments
client-src/rundump.c - Filter dump and xfsdump arguments using WHITELIST approach

Fix are made for the security issues -
1.	The patch for CVE-2016-10729 issue used WHITELIST approach to filter the tar arguments for runtar application. During the same time options filtering implementation was done for amgtar, amstar and ambsdtar. But those changes were done using the BLACKLIST approach. And hence option “-F” for amgtar application can be used to get the data that should only be allowed by root user. The similar issue was present with amstar application.

2.	The same approach was taken with “rundump” application for exploiting the security issue. “rundump” application was not doing any option filtering.
