### PR TITLE
Use verbose tar indexes

### DIFF
--- a/application-src/amgtar.c
+++ b/application-src/amgtar.c
@@ -1480,16 +1480,18 @@ amgtar_backup(
 	}
 	if (strncmp(line, "block ", 6) == 0) { /* filename */
 	    off_t block_no = g_ascii_strtoull(line+6, NULL, 0);
-	    char *filename = strchr(line, ':');
-	    if (filename) {
-		filename += 2;
-		if (*filename == '.' && *(filename+1) == '/') {
+	    char *indexline = strchr(line, ':');
+	    if (indexline) {
+		indexline += 2;
+		char *filename = strstr(indexline," ./");
+		if (filename) {
+		    filename += 2; /* remove . */
 		    if (argument->dle.create_index) {
-			fprintf(indexstream, "%s\n", &filename[1]); /* remove . */
+			fprintf(indexstream, "%s\n", indexline);
 		    }
 		    if (argument->state_stream != -1) {
 			char *s = g_strdup_printf("%lld %s\n",
-					 (long long)block_no, &filename[1]);
+					 (long long)block_no, filename);
 			guint a = full_write(argument->state_stream, s, strlen(s));
 			if (a < strlen(s)) {
 			    g_debug("Failed to write to the state stream: %s",
@@ -1500,7 +1502,7 @@ amgtar_backup(
 			       am_has_feature(argument->amfeatures,
 					      fe_sendbackup_state)) {
 			fprintf(mesgstream, "sendbackup: state %lld %s\n",
-			        (long long)block_no, &filename[1]);
+			        (long long)block_no, filename);
 		    }
 		}
 	    }
@@ -2078,7 +2080,7 @@ amgtar_index(
     g_ptr_array_add(argv_ptr, g_strdup(gnutar_path));
     /* ignore trailing zero blocks on input (this was the default until tar-1.21) */
     g_ptr_array_add(argv_ptr, g_strdup("--ignore-zeros"));
-    g_ptr_array_add(argv_ptr, g_strdup("-tf"));
+    g_ptr_array_add(argv_ptr, g_strdup("-tvf"));
     g_ptr_array_add(argv_ptr, g_strdup("-"));
     g_ptr_array_add(argv_ptr, NULL);
 
@@ -2391,6 +2393,7 @@ GPtrArray *amgtar_build_argv(
 
     g_ptr_array_add(argv_ptr, g_strdup("--create"));
     if (command == CMD_BACKUP && argument->dle.create_index) {
+        g_ptr_array_add(argv_ptr, g_strdup("--verbose"));
         g_ptr_array_add(argv_ptr, g_strdup("--verbose"));
         g_ptr_array_add(argv_ptr, g_strdup("--block-number"));
     }

--- a/server-src/amindexd.c
+++ b/server-src/amindexd.c
@@ -233,15 +233,16 @@ process_ls_dump(
     int		recursive,
     GPtrArray **emsg)
 {
-    char line[STR_SIZE], old_line[STR_SIZE];
+    char line[STR_SIZE], old_filename[STR_SIZE];
     char *filename = NULL;
     char *dir_slash = NULL;
     FILE *fp;
     char *s;
     int ch;
     size_t len_dir_slash;
+    char *filename_start = NULL;
 
-    old_line[0] = '\0';
+    old_filename[0] = '\0';
     if (g_str_equal(dir, "/")) {
 	dir_slash = g_strdup(dir);
     } else {
@@ -266,12 +267,22 @@ process_ls_dump(
     len_dir_slash=strlen(dir_slash);
 
     while (fgets(line, STR_SIZE, fp) != NULL) {
+	if(line[0] == '/') {
+            filename_start = line;
+	} else {
+	    /* tar continually adjusts the output so we must continually 
+	     * search for the filename */
+	    filename_start = strstr(line," ./");
+	    if (filename_start == NULL)
+		continue;
+	    filename_start += 2;
+        }
 	if (line[0] != '\0') {
 	    if(strlen(line) > 0 && line[strlen(line)-1] == '\n')
 		line[strlen(line)-1] = '\0';
-	    if (g_str_has_prefix(line, dir_slash )) {
+	    if (g_str_has_prefix(filename_start, dir_slash )) {
 		if(!recursive) {
-		    s = line + len_dir_slash;
+		    s = filename_start + len_dir_slash;
 		    ch = *s++;
 		    while(ch && ch != '/')
 			ch = *s++;/* find end of the file name */
@@ -280,9 +291,9 @@ process_ls_dump(
 		    }
 		    s[-1] = '\0';
 		}
-		if(!g_str_equal(line, old_line)) {
-		    add_dir_list_item(dump_item, line);
-		    strcpy(old_line, line);
+		if(!g_str_equal(filename_start, old_filename)) {
+		    add_dir_list_item(dump_item, filename_start);
+		    strcpy(old_filename, filename_start);
 		}
 	    }
 	}
@@ -809,6 +820,7 @@ is_dir_valid_opaque(
     char *filename = NULL;
     size_t ldir_len;
     GPtrArray *emsg = NULL;
+    char *filename_start = NULL;
 
     if (get_config_name() == NULL || dump_hostname == NULL || disk_name == NULL) {
 	reply(502, _("Must set config,host,disk before asking about directories"));
@@ -866,11 +878,21 @@ is_dir_valid_opaque(
 	    return -1;
 	}
 	while (fgets(line, STR_SIZE, fp) != NULL) {
+	    if(line[0] == '/') {
+		filename_start = line;
+	    } else {
+		/* tar continually adjusts the output so we must continually 
+		 * search for the filename */
+		filename_start = strstr(line," ./");
+		if (filename_start == NULL)
+		    continue;
+		filename_start += 2;
+            }
 	    if (line[0] == '\0')
 		continue;
 	    if(strlen(line) > 0 && line[strlen(line)-1] == '\n')
 		line[strlen(line)-1] = '\0';
-	    if (strncmp(line, ldir, ldir_len) != 0) {
+	    if (strncmp(filename_start, ldir, ldir_len) != 0) {
 		continue;			/* not found yet */
 	    }
 	    amfree(filename);
@@ -2104,11 +2126,11 @@ uncompress_file(
 	    gchar *tmpdir = getconf_str(CNF_TMPDIR);
 	    pid_sort = pipespawn(SORT_PATH, STDIN_PIPE|STDERR_PIPE, 0,
 				 &pipe_to_sort, &indexfd, &sort_errfd,
-				 SORT_PATH, "-T", tmpdir, NULL);
+				 SORT_PATH, "-k", "6", "-T", tmpdir, NULL);
 	} else {
 	    pid_sort = pipespawn(SORT_PATH, STDIN_PIPE|STDERR_PIPE, 0,
 				 &pipe_to_sort, &indexfd, &sort_errfd,
-				 SORT_PATH, NULL);
+				 SORT_PATH, "-k", "6", NULL);
 	}
 	aclose(indexfd);
 
@@ -2129,9 +2151,7 @@ uncompress_file(
 	case 0:
 	    while (fgets(line, STR_SIZE, pipe_stream) != NULL) {
 		if (line[0] != '\0') {
-		    if (strchr(line,'/')) {
-			full_write(pipe_to_sort,line,strlen(line));
-		    }
+		    full_write(pipe_to_sort,line,strlen(line));
 		}
 	    }
 	    exit(0);


### PR DESCRIPTION
I had a need to have full index meta-data for my backups so I could compare what had changed between two backups.  This patch causes tar to emit details about the contents of the archive and stores it as the index.  amindexd is modified to be able to parse either the new full index format or the older version.