### PR TITLE
(Debian style OS) patches to change /etc/dumpdates path to /var/lib/dumpdates 

### DIFF
--- a/client-src/amandates.c
+++ b/client-src/amandates.c
@@ -28,7 +28,7 @@
 /*
  * $Id: amandates.c,v 1.21 2006/07/25 18:35:21 martinea Exp $
  *
- * manage amandates file, that mimics /etc/dumpdates, but stores
+ * manage amandates file, that mimics /var/lib/dumpdates, but stores
  * GNUTAR dates
  */
 
@@ -333,7 +333,7 @@ import_dumpdates(
 
     devname = amname_to_devname(amdp->name);
 
-    if((dumpdf = fopen("/etc/dumpdates", "r")) == NULL) {
+    if((dumpdf = fopen("/var/lib/dumpdates", "r")) == NULL) {
 	amfree(devname);
 	return;
     }

--- a/client-src/selfcheck.c
+++ b/client-src/selfcheck.c
@@ -1581,8 +1581,8 @@ check_overall(void)
 	delete_message(selfcheck_print_message(check_file_message(COMPRESS_PATH, X_OK)));
 
     if (need_dump || need_xfsdump ) {
-	if (check_file_exist("/etc/dumpdates")) {
-	    delete_message(selfcheck_print_message(check_file_message("/etc/dumpdates",
+	if (check_file_exist("/var/lib/dumpdates")) {
+	    delete_message(selfcheck_print_message(check_file_message("/var/lib/dumpdates",
 #ifdef USE_RUNDUMP
 		       F_OK
 #else
@@ -1602,8 +1602,8 @@ check_overall(void)
     }
 
     if (need_vdump) {
-	if (check_file_exist("/etc/vdumpdates")) {
-            delete_message(selfcheck_print_message(check_file_message("/etc/vdumpdates", F_OK)));
+	if (check_file_exist("/var/lib/vdumpdates")) {
+            delete_message(selfcheck_print_message(check_file_message("/var/lib/vdumpdates", F_OK)));
 	}
     }
 
@@ -1615,6 +1615,7 @@ check_overall(void)
     check_space(AMANDA_DBGDIR, (off_t)64);	/* for amandad i/o */
 #endif
 
+    check_space("/var/lib", (off_t)64);		/* for /var/lib/dumpdates writing */
     check_space("/etc", (off_t)64);		/* for /etc/dumpdates writing */
     }
 }

--- a/common-src/ammessage.c
+++ b/common-src/ammessage.c
@@ -1424,7 +1424,7 @@ set_message(
     } else if (message->code == 3600085) {
 	msg = "unable to open /etc/amandapass: %{errnostr}";
     } else if (message->code == 3600086) {
-	msg = "dump will not be able to create the /etc/dumpdates file: %{errnostr}";
+	msg = "dump will not be able to create the /var/lib/dumpdates file: %{errnostr}";
     } else if (message->code == 3600087) {
 	msg = "%{device}: samba access error: %{errmsg}";
     } else if (message->code == 3600088) {

--- a/example/amanda.conf.in
+++ b/example/amanda.conf.in
@@ -450,7 +450,7 @@ define tapetype SEAGATE-ULTRIUM-LTO {
 #   program	- specify the dump system to use.  Valid values are "DUMP",
 #                 or "GNUTAR".  Default: [program "DUMP"].
 #   record	- record the backup in the time-stamp-database of the backup
-#		  program (e.g. /etc/dumpdates for DUMP or
+#		  program (e.g. /var/lib/dumpdates for DUMP or
 #		  @GNUTAR_LISTED_INCREMENTAL_DIR@ for GNUTAR.).
 #		  Default: [record yes]
 #   skip-full	- skip the disk when a level 0 is due, to allow full backups
@@ -611,7 +611,7 @@ define dumptype nocomp-high {
 
 define dumptype nocomp-test {
     global
-    comment "test dump without compression, no /etc/dumpdates recording"
+    comment "test dump without compression, no /var/lib/dumpdates recording"
     compress none
     record no
     priority medium
@@ -619,7 +619,7 @@ define dumptype nocomp-test {
 
 define dumptype comp-test {
     nocomp-test
-    comment "test dump with compression, no /etc/dumpdates recording"
+    comment "test dump with compression, no /var/lib/dumpdates recording"
     compress client fast
 }
 

--- a/example/template.d/dumptypes
+++ b/example/template.d/dumptypes
@@ -106,7 +106,7 @@
 #   program	- specify the dump system to use.  Valid values are "DUMP" 
 #		  "STAR" and "GNUTAR".  Default: [program "DUMP"].
 #   record	- record the backup in the time-stamp-database of the backup
-#		  program (e.g. /etc/dumpdates for DUMP or
+#		  program (e.g. /var/lib/dumpdates for DUMP or
 #		  /var/lib/amanda/gnutar-lists for GNUTAR.).
 #		  Default: [record yes]
 #   skip-full	- skip the disk when a level 0 is due, to allow full backups
@@ -302,7 +302,7 @@ define dumptype nocomp-high {
 
 define dumptype nocomp-test {
     global
-    comment "test dump without compression, no /etc/dumpdates recording"
+    comment "test dump without compression, no /var/lib/dumpdates recording"
     compress none
     record no
     priority medium
@@ -310,7 +310,7 @@ define dumptype nocomp-test {
 
 define dumptype comp-test {
     nocomp-test
-    comment "test dump with compression, no /etc/dumpdates recording"
+    comment "test dump with compression, no /var/lib/dumpdates recording"
     compress client fast
 }
 

--- a/man/entities/global.entities.in
+++ b/man/entities/global.entities.in
@@ -99,7 +99,7 @@
 <!ENTITY tapelist '<manref name="tapelist" vol="5"/>'>
 
 <!-- IDs for files used by AMANDA-->
-<!ENTITY dumpdates '<filename>/etc/dumpdates</filename>'>
+<!ENTITY dumpdates '<filename>/var/lib/dumpdates</filename>'>
 
 <!-- IDs for AMANDA commands-->
 <!ENTITY amadmin ' <command>amadmin</command>'>

--- a/man/xml-source/amanda.conf.5.xml
+++ b/man/xml-source/amanda.conf.5.xml
@@ -2395,7 +2395,7 @@ must be kept secret.
   <listitem>
 <para>Default:
 <amkeyword>yes</amkeyword>.
-Whether to ask the backup program to update its database (e.g. <filename>/etc/dumpdates</filename>
+Whether to ask the backup program to update its database (e.g. <filename>/var/lib/dumpdates</filename>
 for DUMP or <filename>/usr/local/var/amanda/gnutar-lists</filename> for GNUTAR) of time stamps.
 This is normally enabled for daily backups and turned off for periodic archival runs.</para>
   </listitem>

--- a/man/xml-source/disklist.5.xml
+++ b/man/xml-source/disklist.5.xml
@@ -129,7 +129,7 @@ file.
 specify backup related parameters,
 such as whether to compress the backups,
 whether to record backup results in
-<filename>/etc/dumpdates</filename>, the disk's relative priority, etc.</para>
+<filename>/var/lib/dumpdates</filename>, the disk's relative priority, etc.</para>
   </listitem>
   </varlistentry>
   <varlistentry>

--- a/server-src/diskfile.h
+++ b/server-src/diskfile.h
@@ -120,7 +120,7 @@ typedef struct disk_s {
     char	*clnt_decrypt_opt;	/* client-side decryption option parameter to use */
     double	comprate[2];		/* default compression rates */
     /* flag options */
-    int		record;			/* record dump in /etc/dumpdates ? */
+    int		record;			/* record dump in /var/lib/dumpdates ? */
     int		skip_incr;		/* incs done externally ? */
     int		skip_full;		/* fulls done externally ? */
     int		orig_holdingdisk;	/* original holdingdisk setting */


### PR DESCRIPTION
These were shown to me as a standard set of patches already in Debian distributions.   Seems to be straightforward substitutions.

In my humble opinion... everything that gets logged/stored over time should be under /var/lib or /var/spool or /var/cache to show its increasing in size.