### PR TITLE
(Debian style, but common) patch to fix lintian manpage about use of /usr/adm 

### DIFF
--- a/common-src/conffile.c
+++ b/common-src/conffile.c
@@ -6424,9 +6424,9 @@ init_defaults(
     conf_init_str(&conf_data[CNF_CHANGERFILE]             , "changer");
     conf_init_str   (&conf_data[CNF_TAPELIST]             , "tapelist");
     conf_init_str   (&conf_data[CNF_DISKFILE]             , "disklist");
-    conf_init_str   (&conf_data[CNF_INFOFILE]             , "/usr/adm/amanda/curinfo");
-    conf_init_str   (&conf_data[CNF_LOGDIR]               , "/usr/adm/amanda");
-    conf_init_str   (&conf_data[CNF_INDEXDIR]             , "/usr/adm/amanda/index");
+    conf_init_str   (&conf_data[CNF_INFOFILE]             , CONFIG_DIR "/curinfo");
+    conf_init_str   (&conf_data[CNF_LOGDIR]               , CONFIG_DIR);
+    conf_init_str   (&conf_data[CNF_INDEXDIR]             , CONFIG_DIR "/index");
     conf_init_ident    (&conf_data[CNF_TAPETYPE]             , "DEFAULT_TAPE");
     conf_init_identlist(&conf_data[CNF_HOLDINGDISK]          , NULL);
     conf_init_int      (&conf_data[CNF_DUMPCYCLE]            , CONF_UNIT_NONE, 10);

--- a/example/amanda.conf.in
+++ b/example/amanda.conf.in
@@ -207,7 +207,7 @@ holdingdisk hd1 {
 
 # Amanda needs a few Mb of diskspace for the log and debug files,
 # as well as a database.  This stuff can grow large, so the conf directory
-# isn't usually appropriate.  Some sites use /usr/local/var and some /usr/adm.
+# isn't usually appropriate.  Some sites use /usr/local/var and some /var/lib.
 # Create an amanda directory under there.  You need a separate infofile and
 # logdir for each configuration, so create subdirectories for each conf and
 # put the files there.  Specify the locations below.

--- a/example/chg-multi.conf
+++ b/example/chg-multi.conf
@@ -51,7 +51,7 @@ needeject 0
 ejectdelay 0
 
 # Names a status file where the current ``changer'' state is stored.
-statefile /usr/adm/amanda/csd/changer-status
+statefile /etc/amanda/csd/changer-status
 
 # What are the slot numbers used in the tape rack?
 firstslot 1

--- a/example/template.d/advanced.conf.in
+++ b/example/template.d/advanced.conf.in
@@ -76,7 +76,7 @@ autoflush no
 
 # Amanda needs a few Mb of diskspace for the log and debug files,
 # as well as a database.  This stuff can grow large, so the conf directory
-# isn't usually appropriate.  Some sites use /usr/local/var and some /usr/adm.
+# isn't usually appropriate.  Some sites use /usr/local/var and some /var/lib.
 # Create an amanda directory under there.  You need a separate infofile and
 # logdir for each configuration, so create subdirectories for each conf and
 # put the files there.  Specify the locations below.

--- a/man/xml-source/amanda.conf.5.xml
+++ b/man/xml-source/amanda.conf.5.xml
@@ -944,7 +944,7 @@ Relative pathnames are relative to the configuration directory.
   <term><amkeyword>indexdir</amkeyword> <amtype>string</amtype></term>
   <listitem>
 <para>Default
-<amdefault>&quot;/usr/adm/amanda/index&quot;</amdefault>.
+<amdefault>&quot;/etc/amanda/index&quot;</amdefault>.
 The directory where index files (backup image catalogues) are stored.
 Index files are
 only generated for filesystems whose
@@ -959,7 +959,7 @@ option enabled.</para>
   <term><amkeyword>infofile</amkeyword> <amtype>string</amtype></term>
   <listitem>
 <para>Default:
-<amdefault>&quot;/usr/adm/amanda/curinfo&quot;</amdefault>.
+<amdefault>&quot;/etc/amanda/curinfo&quot;</amdefault>.
 The file or directory name for the historical information database.
 If Amanda was configured to use DBM databases, this is the base file
 name for them.
@@ -1026,7 +1026,7 @@ tape label to any blank tape she encounters.</para>
   <term><amkeyword>logdir</amkeyword> <amtype>string</amtype></term>
   <listitem>
 <para>Default:
-<amdefault>&quot;/usr/adm/amanda&quot;</amdefault>.
+<amdefault>&quot;/etc/amanda&quot;</amdefault>.
 The directory for the
 <command>amdump</command>
 and


### PR DESCRIPTION
Several defaults include /usr/adm as the path for index files and logs and the like.

Though I am for a full change away from /etc/ for mutable/appendable files (toward /var/spool)  ... it is better than an almost totally-missing Linux directory.