### PR TITLE
remove stdin interactivity references 

### DIFF
--- a/perl/Amanda/Interactivity.pm
+++ b/perl/Amanda/Interactivity.pm
@@ -28,7 +28,7 @@ Amanda::Interactivity -- Parent class for user interactivity modules
 
     use Amanda::Interactivity;
 
-    my $inter = Amanda::Interactivity->new(name => 'stdin');
+    my $inter = Amanda::Interactivity->new(name => 'tty');
     $inter->user_request(
 	message => "Insert Volume labelled 'MY_LABEL-001' in changer DLT",
 	label => 'MY_LABEL-001',

--- a/server-src/amtape.pl
+++ b/server-src/amtape.pl
@@ -495,7 +495,7 @@ sub {
 	    }
 	};
 
-	$interactivity = Amanda::Interactivity->new(name => 'stdin');
+	$interactivity = Amanda::Interactivity->new(name => 'tty');
 	($storage, $chg) = load_changer($finished_cb) or return;
 	$scan = Amanda::Recovery::Scan->new(chg => $chg,
 					    interactivity => $interactivity);


### PR DESCRIPTION
This was dated pretty recently (20180314) and seems straightforward.

I've not tested it nor examined it closely yet.