### PR TITLE
Added library link targets 

### DIFF
--- a/amar-src/Makefile.am
+++ b/amar-src/Makefile.am
@@ -26,7 +26,8 @@ noinst_HEADERS = \
 sbin_PROGRAMS = amarchiver
 
 amarchiver_SOURCES = amarchiver.c
-amarchiver_LDADD = libamar.la
+amarchiver_LDADD = libamar.la \
+	../common-src/libamanda.la
 
 # automake-style tests
 
@@ -35,4 +36,5 @@ noinst_PROGRAMS = $(TESTS)
 
 amar_test_SOURCES = amar-test.c
 amar_test_LDADD = libamar.la \
-	../common-src/libtestutils.la
+	../common-src/libtestutils.la \
+	../common-src/libamanda.la

--- a/ndmp-src/Makefile.am
+++ b/ndmp-src/Makefile.am
@@ -205,10 +205,12 @@ amndmjob_SOURCES = amndmjob_main.c \
 		      amndma_tape_simulator.c
 
 ndmjob_LDADD = libndmjob.la \
-		   ../common-src/libamanda.la
+		   ../common-src/libamanda.la \
+		   libndmlib.la
 
 amndmjob_LDADD = libndmjob.la \
-		   ../common-src/libamanda.la
+		   ../common-src/libamanda.la \
+		   libndmlib.la
 
 ndmp0_xdr.c : ndmp0.x
 	rm -f ndmp0_xdr.c

--- a/perl/Makefile.am
+++ b/perl/Makefile.am
@@ -138,6 +138,8 @@ libDevice_la_SOURCES = Amanda/Device.c $(AMGLUE_SWG)
 libDevice_la_LDFLAGS = $(PERL_EXT_LDFLAGS)
 libDevice_la_LIBADD = amglue/libamglue.la \
 	$(top_builddir)/device-src/libamdevice.la \
+	$(top_builddir)/xfer-src/libamxfer.la \
+	$(top_builddir)/ndmp-src/libndmlib.la \
 	$(top_builddir)/common-src/libamanda.la
 Amanda_DATA += Amanda/Device.pm
 MAINTAINERCLEANFILES += Amanda/Device.c Amanda/Device.pm

--- a/server-src/Makefile.am
+++ b/server-src/Makefile.am
@@ -89,6 +89,8 @@ amlibexec_SCRIPTS = $(amlibexec_SCRIPTS_PERL) $(amlibexec_SCRIPTS_SHELL)
 LDADD = ../common-src/libamanda.la   \
 	libamserver.la               \
 	../device-src/libamdevice.la     \
+	../xfer-src/libamxfer.la         \
+	../ndmp-src/libndmlib.la         \
 	../common-src/libamanda.la
 
 libamserver_la_SOURCES=	amindex.c	cmdfile.c \

--- a/xfer-src/Makefile.am
+++ b/xfer-src/Makefile.am
@@ -57,7 +57,8 @@ noinst_PROGRAMS = $(TESTS)
 xfer_test_SOURCES = xfer-test.c
 xfer_test_LDADD = \
 	../common-src/libtestutils.la \
-	libamxfer.la
+	libamxfer.la \
+	../common-src/libamanda.la
 
 # lint support
 


### PR DESCRIPTION
These are needed using modern DT_RUNPATH instead of DT_RPATH.   In the RUNPATH technique, there is no per-library dynamic runpath to find other dependent libs.

This is a security-fix in that a dynamic library cannot go and reach far beyond the original linkage flags of the executable.   Even so ... it requires more careful linking of dep libs and the originals.