### PR TITLE
use wildcard to force samba to estimate from dir

### DIFF
--- a/application-src/amsamba.pl
+++ b/application-src/amsamba.pl
@@ -516,9 +516,9 @@ sub command_estimate {
 	    push @ARGV, "-D", $self->{subdir},
 	}
 	if ($level == 0) {
-	    push @ARGV, "-c", "archive 0;recurse;du";
+	    push @ARGV, "-c", "archive 0;recurse;du *"; # needs '*' for current dir (from {subdir}) and below
 	} else {
-	    push @ARGV, "-c", "archive 1;recurse;du";
+	    push @ARGV, "-c", "archive 1;recurse;du *";
 	}
 	debug("execute: " . $self->{smbclient} . " " .
 	      join(" ", @ARGV));


### PR DESCRIPTION
Tested several other techniques but the simplest was this.

It seems (by testing . which failed and ./ which succeeded then failed) that this is the best estimate possible for a specific dir.