### PR TITLE
add platform-detection to substitute.pl

### DIFF
--- a/packaging/common/substitute.pl
+++ b/packaging/common/substitute.pl
@@ -71,8 +71,12 @@ sub find_platform_info {
     my $rpmarch = get_arch();
     my $debarch = get_debian_pkg_arch();
 
-    if ( $rpmarch !~ m{x86_64|amd64|i686|i386} || $debarch !~ m{x86_64|amd64|i686|i386} ) {
-        print STDERR "ERROR: get_platform_info(): did not find arch \"$rpmarch\" or \"$debarch\"\n"; 
+    if ( $rpmarch && $rpmarch !~ m{x86_64|amd64|i686|i386} ) {
+        print STDERR "ERROR: get_platform_info(): did not find rpm arch \"$rpmarch\"\n"; 
+        return [];
+    }
+    if ( $debarch && $debarch !~ m{x86_64|amd64|i686|i386} ) {
+        print STDERR "ERROR: get_platform_info(): did not find deb arch \"$debarch\"\n"; 
         return [];
     }
 

--- a/packaging/common/substitute.pl
+++ b/packaging/common/substitute.pl
@@ -111,11 +111,6 @@ sub find_platform_info {
     $RELVER2 =~ s/\D(\d+)/$1/; 
     $RELVER2 =~ s/\D.*$//;
 
-    $arch="amd64" 
-       if ( $RELTYPES =~ m/debian|ubuntu/i && $arch eq "x86_64" );
-    $arch="i386" 
-       if ( $RELTYPES =~ m/debian|ubuntu/i && $arch eq "i686" );
-
     return [ ".$RELVER.pkg", "SunOS", $RELVER ]
        if ( $RELTYPES eq "/etc/release" );
 


### PR DESCRIPTION
This came from various types of work in dealing with all the distros.

The macro-tree system in the .spec files leaves a lot to be desired, so to keep 20 versions in test here (and more needed) ... we should have a better technique to adapt, the little we need it, to each Linux distro and name the packages as made.