### PR TITLE
remove strange use of @prefix@

### DIFF
--- a/example/template.d/amanda-harddisk.conf.in
+++ b/example/template.d/amanda-harddisk.conf.in
@@ -12,7 +12,7 @@ tapecycle 10 tapes             # the number of tapes in rotation
 runtapes 1                     # number of tapes to be used in a single run of amdump
 
 define changer my_vtapes {
-    tpchanger "chg-disk:/@prefix@/var/lib/amanda/vtapes/@DEFAULT_CONFIG@"
+    tpchanger "chg-disk:@localstatedir@/lib/amanda/vtapes/@DEFAULT_CONFIG@"
     property "num-slot" "10"
     property "auto-create-slot" "yes"
 }


### PR DESCRIPTION
A simple fix for Installcheck/full-tests that also makes sense:  
    
Don't use "/@prefix@/var/lib/amanda" as the home dir... but use @localstatedir@/lib/amanda as the Perl does.