### PR TITLE
modernize s3/aws interface

### DIFF
--- a/device-src/s3.h
+++ b/device-src/s3.h
@@ -556,6 +556,7 @@ typedef struct lifecycle_action {
 
 typedef struct lifecycle_rule {
     char *id;
+    char *filter;
     char *prefix;
     char *status;
     lifecycle_action *transition;


### PR DESCRIPTION
This is to handle the "filter=" URL attribute (in place of "id=" and others) as well as to pass on a 'content-md5' header with a prepared MD5 hash for a lifecycle query.  (? limited knowledge here ?).

This was proven to solve our issues with AWS in several ways.