### PR TITLE
3 5.default amanda security

### DIFF
--- a/packaging/deb/amanda-backup-client.conffiles
+++ b/packaging/deb/amanda-backup-client.conffiles
@@ -1,0 +1,1 @@
+/etc/amanda-security.conf

--- a/packaging/deb/amanda-backup-server.conffiles
+++ b/packaging/deb/amanda-backup-server.conffiles
@@ -1,0 +1,1 @@
+/etc/amanda-security.conf

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -131,6 +131,7 @@ binary-arch: build
 	echo "---->dh_installdocs: " >> $(log)
 	dh_installdocs -v >> $(log) 2>&1
 	install -d $(r)/$(DOCDIR)/amanda-common/examples
+	install -m 644 common-src/amanda-security.conf $(r)/$(SYSCONFDIR)
 	cp -a example/* $(r)/$(DOCDIR)/amanda-common/examples
 	cp ChangeLog $(r)/$(DOCDIR)/amanda-common/changelog
 	echo "---->dh_installchangelogs: " >> $(log)

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -137,9 +137,10 @@ binary-arch: build
 	echo "---->dh_installchangelogs: " >> $(log)
 	dh_installchangelogs -v >> $(log) 2>&1
 	# Here's how we get the perl modules installed into sitelib
-	ls -1d $(r)$(PERLSITELIB)/* $(r)$(SYSCONFDIR)/amanda-security.conf | \
-		sed -e 's|$(r)/||' | \
-		tee -a debian/amanda-backup-server.install debian/amanda-backup-client.install >/dev/null
+	echo "$(PERLSITELIB)/*" >> debian/amanda-backup-server.install
+	echo "$(PERLSITELIB)/*" >> debian/amanda-backup-client.install
+	echo "$(SYSCONFDIR)/amanda-security.conf" >> debian/amanda-backup-server.install
+	echo "$(SYSCONFDIR)/amanda-security.conf" >> debian/amanda-backup-client.install
 	echo "---->dh_install -v --fail-missing: " >> $(log)
 	dh_install -v --sourcedir=$(r) >> $(log) 2>&1
 	echo "---->dh_strip: " >> $(log)

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -137,7 +137,9 @@ binary-arch: build
 	echo "---->dh_installchangelogs: " >> $(log)
 	dh_installchangelogs -v >> $(log) 2>&1
 	# Here's how we get the perl modules installed into sitelib
-	echo $(PERLSITELIB)/* >> debian/amanda-backup-server.install
+	ls -1d $(r)$(PERLSITELIB)/* $(r)$(SYSCONFDIR)/amanda-security.conf | \
+		sed -e 's|$(r)/||' | \
+		tee -a debian/amanda-backup-server.install debian/amanda-backup-client.install >/dev/null
 	echo "---->dh_install -v --fail-missing: " >> $(log)
 	dh_install -v --sourcedir=$(r) >> $(log) 2>&1
 	echo "---->dh_strip: " >> $(log)

--- a/packaging/rpm/amanda.spec.src
+++ b/packaging/rpm/amanda.spec.src
@@ -446,6 +446,7 @@ mkdir -p %{ROOT_LOGDIR}
 
 echo "%{amanda_version_info}" >%{ROOT_AMANDAHOMEDIR}/amanda-release
 
+install -m 644 %{ROOT_SYSCONFDIR}/amanda/amanda-security.conf %{ROOT_SYSCONFDIR}
 # --- Clean up buildroot ---
 
 %clean
@@ -816,6 +817,7 @@ fi
 %doc %{AMANDAHOMEDIR}/template.d/README
 %doc %{AMANDAHOMEDIR}/template.d/dumptypes
 %defattr(0644,root,root,0755)
+%config(noreplace) %{SYSCONFDIR}/amanda-security.conf
 %docdir %{MANDIR}
 %{MANDIR}/man5/amanda.conf.5.gz
 %{MANDIR}/man5/amanda-client.conf.5.gz
@@ -869,6 +871,7 @@ fi
 %docdir %{AMANDAHOMEDIR}/example
 %docdir %{AMANDAHOMEDIR}/template.d
 %defattr(0644,root,root,0755)
+%config(noreplace) %{SYSCONFDIR}/amanda-security.conf
 %docdir %{MANDIR}
 %{MANDIR}/man5/am*
 %{MANDIR}/man5/disklist.5.gz


### PR DESCRIPTION
Use a default-not-replaced config file setting for RPM and Debian formats so that installation of /etc/amanda-security.conf is (by default) ready to work.