### PR TITLE
3 5.modify rpm spec [requires new substitute.pl feature]

### DIFF
--- a/config/amanda/dirs.m4
+++ b/config/amanda/dirs.m4
@@ -221,7 +221,7 @@ AC_DEFUN([AMANDA_EXPAND_DIRS],
 
     AC_ARG_WITH(amperldir,
 	AS_HELP_STRING([--with-amperldir[[[[[=PATH]]]]]],
-		[Where amanda's perl modules are installed; default: installsitelib])
+		[Where amanda's perl modules are installed; default: installsitearch])
 	AS_HELP_STRING([--without-amperldir],
 		[Install amanda's perl modules in $amlibdir/perl]),
 	[
@@ -236,8 +236,8 @@ AC_DEFUN([AMANDA_EXPAND_DIRS],
     )
     # apply the default if no value was given.
     if test x"$AMPERLLIB" = x"DEFAULT"; then
-	eval `$PERL -V:installsitelib`
-	AMPERLLIB=$installsitelib
+	eval `$PERL -V:installsitearch`
+	AMPERLLIB=$installsitearch
     fi
     AC_DEFINE_DIR([amperldir], [AMPERLLIB],
 	[Directory in which perl modules should be installed])

--- a/packaging/common/post_inst_functions.sh
+++ b/packaging/common/post_inst_functions.sh
@@ -17,18 +17,18 @@
 
 add_service() {
     # Only needed on Solaris!
-    entry="amanda       10080/tcp    # amanda backup services"
+    entryA="amanda       10080/tcp    # amanda backup services"
+    entryK="kamanda       10081/tcp    famdc    # amanda backup services (kerberos)"
     # make sure amanda is in /etc/services
-    if [ -z "`grep 'amanda' ${SYSCONFDIR}/services |grep '10080/tcp'`" ] ; then
+    if ! grep -q 'amanda.*10080/tcp' ${SYSCONFDIR}/services; then
         logger "Adding amanda entry to ${SYSCONFDIR}/services."
-        echo "${entry}" >> ${SYSCONFDIR}/services
+        echo "${entryA}" >> ${SYSCONFDIR}/services
     fi
 
-    # make sure kamanda is in /etc/services
-    entry_2="amanda       10081/tcp    famdc    # amanda backup services (kerberos)"
-    if [ -z "`grep 'kamanda' /etc/services |grep '10081/tcp'`" ] ; then
+
+    if ! grep -q 'kamanda.*10081/tcp' ${SYSCONFDIR}/services; then
         logger "Adding kamanda entry to ${SYSCONFDIR}/services."
-        echo "${entry_2}" >> ${SYSCONFDIR}/services
+        echo "${entryK}" >> ${SYSCONFDIR}/services
     fi
 }
 
@@ -92,7 +92,7 @@ get_random_lines() {
 create_ampassphrase() {
     # install am_passphrase file to server
     logger "Checking '${AMANDAHOMEDIR}/.am_passphrase' file."
-    if [ ! -f ${AMANDAHOMEDIR}/.am_passphrase ] ; then
+    if [ ! -f ${AMANDAHOMEDIR}/.am_passphrase -o ! -s ${AMANDAHOMEDIR}/.am_passphrase ] ; then
         # Separate file creation from password creation to ease debugging.
         logger "Creating '${AMANDAHOMEDIR}/.am_passphrase' file."
         log_output_of touch ${AMANDAHOMEDIR}/.am_passphrase || \
@@ -109,30 +109,29 @@ create_ampassphrase() {
         { logger "WARNING:  Could not fix permissions on .am_passphrase" ; return 1; }
 }
 
+
+GPG2=`command -v gpg2 2>/dev/null`
+GPG=`command -v gpg 2>/dev/null`
+GPG_AGENT=`command -v gpg-agent 2>/dev/null`
+if [ -z "$GPG2" -a -z "$GPG" ]; then
+   logger "Error: no gpg"
+elif [ -z "$GPG2" ]; then
+   GPG_EXTRA="--no-use-agent"
+elif [ -z "$GPG_AGENT" ]; then
+   logger "Error: no gpg-agent"
+fi
+
+# NOTE: do NOT attempt to read/log stderr from gpg-agent in bgd
+GPG=${GPG2:-$GPG};   # best available
+
+
 create_amkey() {
     [ -f ${AMANDAHOMEDIR}/.am_passphrase ] || \
         { logger "Error: ${AMANDAHOMEDIR}/.am_passphrase is missing, can't create amcrypt key."; return 1; }
     logger "Creating encryption key for amcrypt"
-    if [ ! -f ${AMANDAHOMEDIR}/.gnupg/am_key.gpg ]; then
+    if [ ! -f ${AMANDAHOMEDIR}/.gnupg/am_key.gpg -o ! -s ${AMANDAHOMEDIR}/.gnupg/am_key.gpg ]; then
         # TODO: don't write this stuff to disk!
         get_random_lines 50 >${AMANDAHOMEDIR}/.gnupg/am_key || return 1
-
-        GPG2=`command -v gpg2 2>/dev/null`
-        if [ "$?" != "0" ]; then
-           GPG=`command -v gpg 2>/dev/null`
-           if [ "$?" != "0" ]; then
-                logger "Error: no gpg"
-           else
-                GPG_EXTRA="--no-use-agent"
-           fi
-        else
-           GPG_AGENT=`command -v gpg-agent 2>/dev/null`
-           if [ "$?" != "0" ]; then
-              logger "Error: no gpg-agent"
-           else
-              GPG="$GPG_AGENT --daemon --no-use-standard-socket -- $GPG2"
-           fi
-        fi
 
         exec 3<${AMANDAHOMEDIR}/.am_passphrase
         # setting homedir prevents some errors, but creates a permissions
@@ -166,26 +165,9 @@ check_gnupg() {
         { logger "WARNING:  Could not set permissions on .gnupg dir." ; return 1; }
     # If am_key.gpg and .am_passphrase already existed, we should check
     # if they match!
-    if [ -f ${AMANDAHOMEDIR}/.gnupg/am_key.gpg ] && [ -f ${AMANDAHOMEDIR}/.am_passphrase ]; then
-
-        GPG2=`command -v gpg2 2>/dev/null`
-        if [ "$?" != "0" ]; then
-           GPG=`command -v gpg 2>/dev/null`
-           if [ "$?" != "0" ]; then
-                logger "Error: no gpg"
-           else
-                GPG_EXTRA="--no-use-agent"
-           fi
-        else
-           GPG_AGENT=`command -v gpg-agent 2>/dev/null`
-           if [ "$?" != "0" ]; then
-              logger "Error: no gpg-agent"
-           else
-              GPG="$GPG_AGENT --daemon --no-use-standard-socket -- $GPG2"
-           fi
-        fi
-
+    if [ -s ${AMANDAHOMEDIR}/.gnupg/am_key.gpg -a -s ${AMANDAHOMEDIR}/.am_passphrase ]; then
         exec 3<${AMANDAHOMEDIR}/.am_passphrase
+
         # Perms warning will persist because we are not running as ${amanda_user}
         log_output_of $GPG --homedir ${AMANDAHOMEDIR}/.gnupg \
                 --no-permission-warning \
@@ -318,19 +300,20 @@ check_profile(){
 
 install_client_conf() {
     # Install client config
+    am_confdir=${SYSCONFDIR}/amanda
+    install="install -m 0600 -o ${amanda_user} -g ${amanda_group}"
     if [ "$os" = "SunOS" ] ; then
         install="install -m 0600 -u ${amanda_user} -g ${amanda_group}"
-    else
-        install="install -m 0600 -o ${amanda_user} -g ${amanda_group}"
     fi
-    logger "Checking '${SYSCONFDIR}/amanda/amanda-client.conf' file."
-    if [ ! -f ${SYSCONFDIR}/amanda/amanda-client.conf ] ; then
+    logger "Checking '${am_confdir}/amanda-client.conf' file."
+    if [ ! -f ${am_confdir}/amanda-client.conf ] ; then
         logger "Installing amanda-client.conf."
-        log_output_of ${install} ${AMANDAHOMEDIR}/example/amanda-client.conf \
-            ${SYSCONFDIR}/amanda/ || \
+        log_output_of ${install} \
+           ${AMANDAHOMEDIR}/example/amanda-client.conf \
+	   ${am_confdir}/ || \
                 { logger "WARNING:  Could not install amanda-client.conf" ; return 1; }
     else
-        logger "Note: ${SYSCONFDIR}/amanda/amanda-client.conf exists. Please check ${AMANDAHOMEDIR}/example/amanda-client.conf for updates."
+        logger "Note: ${am_confdir}/amanda-client.conf exists. Please check ${AMANDAHOMEDIR}/example/amanda-client.conf for updates."
     fi
 }
 

--- a/packaging/common/pre_inst_functions.sh
+++ b/packaging/common/pre_inst_functions.sh
@@ -37,7 +37,7 @@ create_user() {
                             -g ${amanda_group} \
                             ${uid_flag} \
                             -d ${AMANDAHOMEDIR} \
-                            -s ${wanted_shell} ${amanda_user}  || \
+                            -s ${wanted_shell} -m ${amanda_user}  || \
                 { logger "WARNING:  Could not create user ${amanda_user}. Installation will fail." ; return 1 ; }
                 logger "Created ${amanda_user} with blank password."
 

--- a/packaging/deb/amanda-backup-client.dirs.src
+++ b/packaging/deb/amanda-backup-client.dirs.src
@@ -1,9 +1,11 @@
 etc/amanda
+usr/lib/%%ARCH%%-linux-gnu/
+usr/lib/amanda/application
 usr/share/lintian/overrides
 usr/share/man/man5
 usr/share/man/man8
 var/amanda
 var/lib/amanda
 var/lib/amanda/gnutar-lists
-var/lib/amanda/example/label-templates
+var/lib/amanda/example
 var/log/amanda

--- a/packaging/deb/amanda-backup-client.install.src
+++ b/packaging/deb/amanda-backup-client.install.src
@@ -1,6 +1,6 @@
 etc/amanda/*
-usr/lib/x86_64-linux-gnu/amanda/*
-usr/lib/x86_64-linux-gnu/amanda/application/*
+usr/lib/%%ARCH%%-linux-gnu/*
+usr/lib/amanda/*
 usr/sbin/amaespipe
 usr/sbin/amcryp*
 usr/sbin/amgpgcrypt

--- a/packaging/deb/amanda-backup-server.dirs.src
+++ b/packaging/deb/amanda-backup-server.dirs.src
@@ -1,10 +1,11 @@
 etc/amanda
-usr/lib/x86_64-linux-gnu/amanda
+usr/lib/%%ARCH%%-linux-gnu/
+usr/lib/amanda/application
 usr/share/lintian/overrides
 usr/share/man/man5
 usr/share/man/man8
 var/amanda
 var/lib/amanda
 var/lib/amanda/gnutar-lists
-var/lib/amanda/example
+var/lib/amanda/example/label-templates
 var/log/amanda

--- a/packaging/deb/amanda-backup-server.install.src
+++ b/packaging/deb/amanda-backup-server.install.src
@@ -1,6 +1,6 @@
 etc/amanda/*
-usr/lib/x86_64-linux-gnu/amanda/application/*
-usr/lib/x86_64-linux-gnu/amanda/*
+usr/lib/%%ARCH%%-linux-gnu/*
+usr/lib/amanda/*
 usr/sbin/*
 usr/share/man/man5/*
 usr/share/man/man7/*

--- a/packaging/deb/buildpkg
+++ b/packaging/deb/buildpkg
@@ -1,87 +1,34 @@
 #! /bin/bash
-set -x
-#### Configure variables.  Feel free to change these, but be careful!
-SRCDIR=$PWD
-# You can pass your own temp directory as an environment variable.
-# This prefix is prepended to all directories during "make install" 
-FAKEROOT="${SRCDIR}/froot"
-# Configure and Compilation directory.
-BUILDDIR="${SRCDIR}/build"
-# Config variables to mirror those in RPM .spec file
-amanda_user=amandabackup
-amanda_group=admin
-PREFIX="/usr"
-EPREFIX="${PREFIX}"
-BINDIR="${EPREFIX}/bin"
-SBINDIR="${EPREFIX}/sbin"
-LIBEXECDIR="${EPREFIX}/lib/amanda"
-DATADIR="${PREFIX}/share"
-SYSCONFDIR="/etc"
-LOCALSTATEDIR="/var"
-AMANDAHOMEDIR="${LOCALSTATEDIR}/lib/amanda"
-LIBDIR="${EPREFIX}/lib"
-INCLUDEDIR="${PREFIX}/include"
-INFODIR="${PREFIX}/info"
-MANDIR="${DATADIR}/man"
-LOGDIR="${LOCALSTATEDIR}/log/amanda"                  
+# We're assuming that you've copied packaging/* from the 
+# amanda-extensions source tree to the amanda source tree.  
 
-#### CHECKS
+# Buildpkg is designed to be used by both buildbot (to automate deb production)
+# and by J Random User (to build a deb for kicks).
+#
+# VERSION: the identifier for the amanda determined from subversion
+#	information.  
+# PKG_NAME_VER: the full version name of amanda we're working on.  This will
+#	become part of the deb name.  {PKG_NAME_VER} gets substituted into
+#	various package files.  
+#
+# Other Hints:
+# Not everyone will want to use the ./configure options we provide.  The
+# easiest way to change them is by editing the rules file.  This fairly easy:
+# rules is a Makefile, so follow gnu makefile rules and edit the define 
+# CONFIG_FLAGS_COMMON variable.  Don't forget trailing backslashes.
+# set -x
 
-if [ ! -f common-src/amanda.h ]
-then
-    echo "'buildpkg' must be run from the root of an otherwise unused amanda source directory." >&2
-    exit 1
-fi
+# set pkg_root also
+pkg_name=amanda
+. ./packaging/common/build_functions.sh
 
-if [ ! -f configure ]
-then
-    echo "The source directory has not been autogen'd -- please download a source distribution tarball or run ./autogen."
-    echo "You will need autoconf, automake, and libtool to run autogen (but not to compile from a distribution tarball)."
-    exit 1
-fi
+# create version files from top ...
+. ./config/set_full_version
 
-# Until we get package revisioning in community.
-[ -f "PKG_REV" ] || echo "1" > PKG_REV
+gen_pkg_build_config $pkg_root
 
-#### Build functions
+gen_pkg_environ
 
-do_substitute() {
-    # We need to edit packaging/deb/changelog to reflect our current distro
-    # and release.  This can't be done within the debian packaging system;
-    # dpkg assumes that packages will have the same name on all releases and
-    # that apt will prevent users from downloading the wrong build.  We want
-    # this information helpfully obvious since we can't rely on apt.
-    file_list="packaging/deb/changelog \
-        packaging/deb/postinst \
-        packaging/deb/postrm \
-        packaging/deb/preinst"
-    for file in ${file_list}; do
-        /usr/bin/perl packaging/common/substitute.pl \
-            ${file}.src ${file} || exit 1
-    done
-}
+[ -n "$PKG_NAME_VER" ] || { declare -p; die "no version to use"; }
 
-do_resources() {
-    # Setup directories and files as dpkg-buildpkg expects.
-    if [ -d debian ]; then
-        rm -rf debian
-    fi
-    cp -Rf packaging/deb debian
-    if [ -d $BUILDDIR ]; then
-        rm -rf $BUILDDIR
-    fi
-    mkdir -p $BUILDDIR
-    cp -Rfp * $BUILDDIR
-}
-
-do_package() {
-
-    echo "Building package"
-    cd $BUILDDIR
-    # Create unsigned packages
-    dpkg-buildpackage -rfakeroot -uc -us
-}
-
-do_substitute
-do_resources
-do_package
+do_package ${PKG_NAME_VER}

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -192,8 +192,10 @@ binary-arch: build
 		$(server)/$(AMLIBEXECDIR)/runtar \
 		$(server)/$(AMLIBEXECDIR)/calcsize \
 		$(server)/$(AMLIBEXECDIR)/ambind
-	echo "Amanda version $(AMVER)" >  $(server)/$(AMANDAHOMEDIR)/amanda-release
-	echo "Amanda version $(AMVER)" >  $(client)/$(AMANDAHOMEDIR)/amanda-release
+	echo "Amanda version $(AMVER)" > $(server)/$(AMANDAHOMEDIR)/amanda-release
+	echo "Amanda version $(AMVER)" > $(client)/$(AMANDAHOMEDIR)/amanda-release
+	[ -s LONG_BRANCH ] && echo "ref=$(cat LONG_BRANCH)" >> $(server)/$(AMANDAHOMEDIR)/amanda-release
+	[ -s LONG_BRANCH ] && echo "ref=$(cat LONG_BRANCH)" >> $(client)/$(AMANDAHOMEDIR)/amanda-release
 	install -o root -g root -m 0644 debian/amanda-backup-client.lintian \
 		$(client)/usr/share/lintian/overrides/amanda-backup-client
 	install -o root -g root -m 0644 debian/amanda-backup-server.lintian \

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -20,6 +20,7 @@ LIBEXECDIR=$(LIBDIR)
 AMLIBEXECDIR=$(LIBEXECDIR)/amanda
 # must be architecture-specific ...
 SHLIBDIR=$(PREFIX)/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+AMLIBDIR=$(SHLIBDIR)/amanda
 MANDIR=$(PREFIX)/share/man
 DOCDIR=$(PREFIX)/share/doc
 SYSCONFDIR=/etc
@@ -30,9 +31,9 @@ LOGDIR=$(LOCALSTATEDIR)/log/amanda
 # libs. If configure finds a different install or you specify a different path using
 # --with-amperldir= make sure you change this variable in the config dirs.m4 as well.
 # NOTE: perl -V:varname emits a final ";".   Don't let it match to make ";;".
-PERLVENDORARCH=$(shell eval "$$(perl -V:installvendorarch)"; echo $$installvendorarch)
-PERLSITEARCH=$(shell eval "$$(perl -V:installsitearch)"; echo $$installsitearch)
-PERLLIBDIR=$(PERLVENDORARCH)
+# PERLVENDORARCH=$(shell eval "$$(perl -V:installvendorarch)"; echo $$installvendorarch)
+# PERLSITEARCH=$(shell eval "$$(perl -V:installsitearch)"; echo $$installsitearch)
+PERLLIBDIR=$(AMLIBDIR)/perl
 AMANDAUSER=amandabackup
 AMANDAGROUP=disk
 WITHOUT_SERVER="False"
@@ -66,13 +67,14 @@ build-stamp: /sbin/dump /usr/bin/smbclient
 		--host=$(DEB_HOST_GNU_TYPE) \
 		--build=$(DEB_BUILD_GNU_TYPE) \
 		--prefix=$(PREFIX) \
-		--libdir=$(SHLIBDIR) \
+		--libdir=$(AMLIBDIR) \
 		--bindir=$(BINDIR) \
 		--mandir=$(MANDIR) \
 		--libexecdir=$(LIBEXECDIR) \
 		--enable-shared \
 		--sysconfdir=$(SYSCONFDIR) \
 		--localstatedir=$(LOCALSTATEDIR) \
+		--with-amlibdir=$(AMLIBDIR) \
 		--with-amperldir=$(PERLLIBDIR) \
 		--with-amdatadir=$(AMANDAHOMEDIR) \
 		--with-gnutar-listdir=$(AMANDAHOMEDIR)/gnutar-lists \

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -15,15 +15,11 @@ AMVER=`cat FULL_VERSION`
 # places during configure, build, and install.
 PREFIX=/usr
 BINDIR=$(PREFIX)/bin
-triplet := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
-ifeq ($(triplet),x86_64-linux-gnu)
-LIBDIR=$(PREFIX)/lib/$(triplet)
-else
 LIBDIR=$(PREFIX)/lib
-endif
-AMLIBDIR=$(LIBDIR)/amanda
 LIBEXECDIR=$(LIBDIR)
 AMLIBEXECDIR=$(LIBEXECDIR)/amanda
+# must be architecture-specific ...
+SHLIBDIR=$(PREFIX)/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 MANDIR=$(PREFIX)/share/man
 DOCDIR=$(PREFIX)/share/doc
 SYSCONFDIR=/etc
@@ -34,9 +30,9 @@ LOGDIR=$(LOCALSTATEDIR)/log/amanda
 # libs. If configure finds a different install or you specify a different path using
 # --with-amperldir= make sure you change this variable in the config dirs.m4 as well.
 # NOTE: perl -V:varname emits a final ";".   Don't let it match to make ";;".
-PERLVENDORARCH=$(shell $(shell perl -V:installvendorarch) echo $$installvendorarch)
-PERLSITEARCH=$(shell $(shell perl -V:installsitearch) echo $$installsitearch)
-PERLLIBDIR=$(PERLSITEARCH)
+PERLVENDORARCH=$(shell eval "$$(perl -V:installvendorarch)"; echo $$installvendorarch)
+PERLSITEARCH=$(shell eval "$$(perl -V:installsitearch)"; echo $$installsitearch)
+PERLLIBDIR=$(PERLVENDORARCH)
 AMANDAUSER=amandabackup
 AMANDAGROUP=disk
 WITHOUT_SERVER="False"
@@ -70,14 +66,13 @@ build-stamp: /sbin/dump /usr/bin/smbclient
 		--host=$(DEB_HOST_GNU_TYPE) \
 		--build=$(DEB_BUILD_GNU_TYPE) \
 		--prefix=$(PREFIX) \
-		--libdir=$(LIBDIR) \
+		--libdir=$(SHLIBDIR) \
 		--bindir=$(BINDIR) \
 		--mandir=$(MANDIR) \
 		--libexecdir=$(LIBEXECDIR) \
 		--enable-shared \
 		--sysconfdir=$(SYSCONFDIR) \
 		--localstatedir=$(LOCALSTATEDIR) \
-		--with-amlibdir=$(AMLIBDIR) \
 		--with-amperldir=$(PERLLIBDIR) \
 		--with-amdatadir=$(AMANDAHOMEDIR) \
 		--with-gnutar-listdir=$(AMANDAHOMEDIR)/gnutar-lists \

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -91,6 +91,7 @@ build-stamp: /sbin/dump /usr/bin/smbclient
 		--with-debugging=$(LOGDIR) \
 		--with-ssh-security \
 		--with-assertions \
+		--with-failure-code \
 		--enable-s3-device \
 		--disable-installperms
 	touch missing

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -30,11 +30,12 @@ SYSCONFDIR=/etc
 LOCALSTATEDIR=/var
 AMANDAHOMEDIR=$(LOCALSTATEDIR)/lib/amanda
 LOGDIR=$(LOCALSTATEDIR)/log/amanda
-# Extract the perl site_lib directory.  This is used to install amanda's perl 
+# Extract the perl directory.  This is used to install amanda's perl 
 # libs. If configure finds a different install or you specify a different path using
-# --with-amperldir= make sure you change this variable as well.
-PERLVENDORARCH=$(shell $(shell perl -V:installvendorarch); echo $$installvendorarch)
-PERLSITEARCH=$(shell $(shell perl -V:installsitearch); echo $$installsitearch)
+# --with-amperldir= make sure you change this variable in the config dirs.m4 as well.
+# NOTE: perl -V:varname emits a final ";".   Don't let it match to make ";;".
+PERLVENDORARCH=$(shell $(shell perl -V:installvendorarch) echo $$installvendorarch)
+PERLSITEARCH=$(shell $(shell perl -V:installsitearch) echo $$installsitearch)
 PERLLIBDIR=$(PERLSITEARCH)
 AMANDAUSER=amandabackup
 AMANDAGROUP=disk
@@ -76,6 +77,8 @@ build-stamp: /sbin/dump /usr/bin/smbclient
 		--enable-shared \
 		--sysconfdir=$(SYSCONFDIR) \
 		--localstatedir=$(LOCALSTATEDIR) \
+		--with-amlibdir=$(AMLIBDIR) \
+		--with-amperldir=$(PERLLIBDIR) \
 		--with-amdatadir=$(AMANDAHOMEDIR) \
 		--with-gnutar-listdir=$(AMANDAHOMEDIR)/gnutar-lists \
 		--with-index-server=localhost \

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -33,7 +33,9 @@ LOGDIR=$(LOCALSTATEDIR)/log/amanda
 # Extract the perl site_lib directory.  This is used to install amanda's perl 
 # libs. If configure finds a different install or you specify a different path using
 # --with-amperldir= make sure you change this variable as well.
-PERLSITELIB=$(shell perl -V:installsitelib|sed -e"s:installsitelib='/::;s:'\;::")
+PERLVENDORARCH=$(shell $(shell perl -V:installvendorarch); echo $$installvendorarch)
+PERLSITEARCH=$(shell $(shell perl -V:installsitearch); echo $$installsitearch)
+PERLLIBDIR=$(PERLSITEARCH)
 AMANDAUSER=amandabackup
 AMANDAGROUP=disk
 WITHOUT_SERVER="False"
@@ -56,6 +58,7 @@ WD=$(CWD)
 build: build-stamp
 build-stamp: /sbin/dump /usr/bin/smbclient
 	dh_testdir
+	[ -f ./configure ] || ./autogen
 	./configure \
 		MAKEFLAGS="-j1 " \
 		CFLAGS="-pipe " \

--- a/packaging/rpm/amanda.spec.src
+++ b/packaging/rpm/amanda.spec.src
@@ -295,7 +295,7 @@ find-req-script
 
 [ -x ./configure ] || ./autogen
 
-# Set PKG_CONFIG_PATH=some/path if some/path was set on the command line, or by 
+# Set PKG_CONFIG_PATH=some/path if some/path was set on the command line, or by
 # the platform detection bits.
 # without_ipv6 should only be defined on rhel3.
 # LDFLAGS macro is defined except on rhel3.
@@ -338,7 +338,7 @@ find-req-script
         %{?without_ipv6}
 
 # -s LIBTOOLFLAGS=--silent
-make -j$(nproc) 
+make -j$(nproc)
 
 # --- Install to buildroot ---
 
@@ -352,7 +352,7 @@ else
         exit -1
 fi
 
-# -s LIBTOOLFLAGS=--silent 
+# -s LIBTOOLFLAGS=--silent
 make -j1 DESTDIR=%{buildroot} install
 
 rm -f %{ROOT_AMANDAHOMEDIR}/example/inetd.conf.amandaclient
@@ -363,8 +363,6 @@ mkdir -p %{ROOT_AMANDAHOMEDIR}/gnutar-lists
 mkdir -p %{ROOT_LOGDIR}
 
 echo "%{amanda_version_info}" >%{ROOT_AMANDAHOMEDIR}/amanda-release
-
-install -m 644 %{ROOT_SYSCONFDIR}/amanda/amanda-security.conf %{ROOT_SYSCONFDIR}
 # --- Clean up buildroot ---
 
 %clean
@@ -735,7 +733,6 @@ fi
 %doc %{AMANDAHOMEDIR}/template.d/README
 %doc %{AMANDAHOMEDIR}/template.d/dumptypes
 %defattr(0644,root,root,0755)
-%config(noreplace) %{SYSCONFDIR}/amanda-security.conf
 %docdir %{MANDIR}
 %{MANDIR}/man5/amanda.conf.5.gz
 %{MANDIR}/man5/amanda-client.conf.5.gz
@@ -789,7 +786,6 @@ fi
 %docdir %{AMANDAHOMEDIR}/example
 %docdir %{AMANDAHOMEDIR}/template.d
 %defattr(0644,root,root,0755)
-%config(noreplace) %{SYSCONFDIR}/amanda-security.conf
 %docdir %{MANDIR}
 %{MANDIR}/man5/am*
 %{MANDIR}/man5/disklist.5.gz

--- a/packaging/rpm/amanda.spec.src
+++ b/packaging/rpm/amanda.spec.src
@@ -250,8 +250,8 @@ Amanda Documentation is available at: http://wiki.zmanda.com/
 %define INCLUDEDIR      %{PREFIX}/include
 %define MANDIR          %{DATADIR}/man
 %define LOGDIR          /var/log/amanda
-%define PERLVENDORARCH   %(eval "perl -V:installvendorarch`"; echo $installvendorarch)
-%define PERLSITEARCH   %(eval "perl -V:installsitearch`"; echo $installsitearch)
+%define PERLVENDORARCH   %(eval $(perl -V:installvendorarch); echo $installvendorarch)
+%define PERLSITEARCH   %(eval $(perl -V:installsitearch); echo $installsitearch)
 %define PERLLIBDIR      %PERLSITEARCH
 %define AMDATADIR	/var/lib/amanda
 

--- a/packaging/rpm/amanda.spec.src
+++ b/packaging/rpm/amanda.spec.src
@@ -363,6 +363,8 @@ mkdir -p %{ROOT_AMANDAHOMEDIR}/gnutar-lists
 mkdir -p %{ROOT_LOGDIR}
 
 echo "%{amanda_version_info}" >%{ROOT_AMANDAHOMEDIR}/amanda-release
+
+install -m 644 %{ROOT_SYSCONFDIR}/amanda/amanda-security.conf %{ROOT_SYSCONFDIR}
 # --- Clean up buildroot ---
 
 %clean
@@ -733,6 +735,7 @@ fi
 %doc %{AMANDAHOMEDIR}/template.d/README
 %doc %{AMANDAHOMEDIR}/template.d/dumptypes
 %defattr(0644,root,root,0755)
+%config(noreplace) %{SYSCONFDIR}/amanda-security.conf
 %docdir %{MANDIR}
 %{MANDIR}/man5/amanda.conf.5.gz
 %{MANDIR}/man5/amanda-client.conf.5.gz
@@ -786,6 +789,7 @@ fi
 %docdir %{AMANDAHOMEDIR}/example
 %docdir %{AMANDAHOMEDIR}/template.d
 %defattr(0644,root,root,0755)
+%config(noreplace) %{SYSCONFDIR}/amanda-security.conf
 %docdir %{MANDIR}
 %{MANDIR}/man5/am*
 %{MANDIR}/man5/disklist.5.gz

--- a/packaging/rpm/amanda.spec.src
+++ b/packaging/rpm/amanda.spec.src
@@ -6,16 +6,16 @@
 #  modify it under the terms of the GNU General Public License
 #  as published by the Free Software Foundation; either version 2
 #  of the License, or (at your option) any later version.
-# 
+#
 #  This program is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 #  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 #  for more details.
-# 
+#
 #  You should have received a copy of the GNU General Public License along
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
-# 
+#
 #  Contact information: Carbonite Inc., 756 N Pastoria Ave
 #  Sunnyvale, CA 94086, USA, or: http://www.zmanda.com
 #
@@ -26,7 +26,7 @@
 
 # Pkg-config sometimes needs its own path set, and we need to allow users to
 # override our guess during detection.  This macro takes care of that.
-# If no --define PKG_CONFIG_PATH was passed and env var $PKG_CONFIG_PATH is 
+# If no --define PKG_CONFIG_PATH was passed and env var $PKG_CONFIG_PATH is
 # set then use the env var.
 %{!?PKG_CONFIG_PATH: %{expand:%(echo ${PKG_CONFIG_PATH:+"%%define PKG_CONFIG_PATH $PKG_CONFIG_PATH"})}}
 
@@ -34,127 +34,22 @@
 # like rhel3 and sles9 can't.
 %define enable_as_needed --enable-as-needed
 
+%define curl libcurl
+
+%define dist       %%PKG_DIST%%
+%define distver    %%PKG_DISTVER%%
+%define disttag    %(A="%%PKG_SUFFIX%%"; A="${A#.}"; echo ${A%%%%.*})
+
 # Define which Distribution we are building:
 # Try to detect the distribution we are building:
 %if %{_vendor} == amazon
     %define dist amazon
-    %define disttag amzn
     %define distver 1
-    %define curl libcurl
-%endif
-%if %{_vendor} == redhat
-    # Fedora symlinks /etc/fedora-release to /etc/redhat-release for at least
-    # fc3-8.  So RHEL and Fedora look at the same file.  Different versions have
-    # different numbers of spaces; hence the use of $3 vs. $4..
-    %if %(awk '$1 == "Fedora" { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist fedora
-        %define disttag fc
-        %define distver %(awk '{print $4}' /etc/redhat-release)
-    %endif
-    # if macro cannot have an empty test and we're just testing the existance
-    %if %{?fedora:yes}%{!?fedora:no} == yes
-        # In theory this should be more reliable than awking for distver.
-        %define distver %{fedora}
-    %endif
-    %if "%{dist}" == "fedora"
-	%if %{distver} <= 8
-	    %define requires_libtermcap Requires: libtermcap.so.2
-	    %define curl curl
-	%endif
-	%if %{distver} >= 9
-	    %define curl libcurl
-	%endif
-        %if %{_host_cpu} == x86_64 && %{_target_cpu} == i686
-                # Do nothing if PKG_CONFIG_PATH was set by the user above.
-                %{!?PKG_CONFIG_PATH: %define PKG_CONFIG_PATH /usr/lib/pkgconfig}
-        %endif
-    %endif
-    %if %(awk '$1 == "Red" && $7 ~ /3.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 3
-        %define tarver 1.14
-	%define requires_libtermcap Requires: libtermcap.so.2
-	%define curl curl
-	%define without_ipv6 --without-ipv6
-	%undefine enable_as_needed
-        %define prereq_sharutils PreReq: sharutils
-    %endif
-    %if %(awk '$1 == "Red" && $7 ~ /4.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 4
-        %define tarver 1.14
-	%define requires_libtermcap Requires: libtermcap.so.2
-	%define curl curl
-        %define prereq_sharutils PreReq: sharutils
-    %endif
-    %if %(awk '$1 == "CentOS" && $3 ~ /4.*/ { exit 1; }' /etc/redhat-release; echo $?)
-	%define dist redhat
-	%define disttag rhel
-	%define distver 4
-	%define tarver 1.14
-	%define requires_libtermcap Requires: libtermcap.so.2
-	%define curl curl
-        %define prereq_sharutils PreReq: sharutils
-    %endif
-    %if %(awk '$1 == "Red" && $7 ~ /5.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 5
-	%define curl curl
-    %endif
-    %if %(awk '$1 == "CentOS" && $3 ~ /5.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 5
-	%define curl curl
-    %endif
-    %if %(awk '$1 == "Red" && $7 ~ /6.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 6
-	%define curl libcurl
-    %endif
-    %if %(awk '$1 == "CentOS" && $4 ~ /6.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 6
-	%define curl curl
-    %endif
-    %if %(awk '$1 == "CentOS" && $4 ~ /7.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 7
-	%define curl libcurl
-    %endif
-    %if %(awk '$1 == "Red" && $7 ~ /7.*/ { exit 1; }' /etc/redhat-release; echo $?)
-        %define dist redhat
-        %define disttag rhel
-        %define distver 7
-	%define curl libcurl
-    %endif
-   
-    # If dist is undefined, we didn't detect.
-    %{!?dist:%define dist unknown}
-%endif
-# Detect Suse variants.
-%if %{_vendor} == "suse"
-    %define dist SuSE
-    %define disttag %(awk '$1=="openSUSE" { print "suse"; } $1=="SUSE" {$3=="Enterprise" ? TAG="sles" : TAG="suse" ; print TAG}' /etc/SuSE-release)
-    # use printf to be sure rpm gets a number type
-    %define distver %(awk '$1=="openSUSE" { printf("%d", $2); } $1=="SUSE" {$3=="Enterprise" ? VER=$5 : VER=$3 ; printf("%d", VER)}' /etc/SuSE-release)
-    %define curl curl
-    %if %{distver} == 9
-        %undefine enable_as_needed
-    %endif
-    %if %{distver} < 11
-        %define prereq_sharutils PreReq: sharutils
-    %endif
+    %define disttag  amzn
 %endif
 
 # Set options per distribution
-%if %{dist} == redhat || %{dist} == fedora
+%if %{dist} == redhat || %{dist} == centos || %{dist} == fedora
     %define rpm_group Applications/Archiving
     %define requires_initscripts Requires: initscripts
 %endif
@@ -163,7 +58,7 @@
 %endif
 
 # Let's die if we haven't detected the distro. This might save some frustration.
-# RPM does not provide a way to  exit gracefully, hence the tag_to_cause_exit. 
+# RPM does not provide a way to  exit gracefully, hence the tag_to_cause_exit.
 %{!?distver: %{error:"Your distribution and its version were not detected."}; %tag_to_cause_exit }
 # Set minimum tar version if it wasn't set in the per-distro section
 %{!?tarver: %define tarver 1.15}
@@ -186,7 +81,7 @@
 Summary: The Amanda Backup and Archiving System
 Name: amanda
 Version: %{amanda_version}
-%define rpm_release %{amanda_release}.%{disttag}%{distver}
+%define rpm_release %{amanda_release}.%{disttag}
 %if %{build_srpm}
 %define rpm_release %{amanda_release}
 %endif
@@ -195,6 +90,7 @@ Source: %{name}-%{version}.tar.gz
 License: http://wiki.zmanda.com/index.php/Amanda_Copyright
 Vendor: Zmanda, Inc.
 Packager: www.zmanda.com
+Url: http://www.zmanda.com/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-%{packer}-buildroot
 Group: %{rpm_group}
 # TODO - Need required versions for these:
@@ -209,6 +105,12 @@ BuildRequires: glib2-devel
 BuildRequires: gettext
 BuildRequires: readline
 BuildRequires: docbook-style-xsl
+# xsltproc for manpages
+BuildRequires: libxslt
+# libtoolize for later autotools
+BuildRequires: libtool
+# rpcgen for libndmp
+BuildRequires: /usr/bin/rpcgen
 BuildRequires: swig
 # Note: newer distros have changed most *-devel to lib*-devel, and added a
 # provides tag for backwards compat.
@@ -218,10 +120,19 @@ BuildRequires: %{curl}-devel >= 7.10.0
 BuildRequires: openssl
 BuildRequires: openssl-devel
 BuildRequires: perl(ExtUtils::Embed)
-BuildRequires: mailx
-%{?prereq_sharutils}
+BuildRequires: ncurses-devel
+# BuildRequires: perl(CPAN) perl(Scalar::List::Utils) perl(IO::Socket::SSL)
+# BuildRequires: perl(Carp) perl(Data::Dumper) perl(YAML)
+# BuildRequires: dump
+# BuildRequires: samba-client
+
+%package backup_client
+Summary: The Amanda Backup and Archiving Client
+Group: %{rpm_group}
+#
+# NOTE: Requires are separated out to final packages only...
+#
 Requires: /bin/awk
-Requires: /bin/date
 Requires: /usr/bin/id
 Requires: /sbin/ldconfig
 Requires: /bin/sh
@@ -231,28 +142,16 @@ Requires: coreutils
 Requires: gettext
 Requires: grep
 Requires: gnuplot
+Requires: xinetd
 Requires: %{curl} >= 7.10.0
 Requires: openssl
-Requires: xinetd
 Requires: perl >= 5.6.0
 Requires: tar >= %{tarver}
 Requires: readline
 Requires: mailx
 %{?requires_libtermcap}
 %{?requires_initscripts}
-
-%package backup_client
-Summary: The Amanda Backup and Archiving Client
-Group: %{rpm_group}
-Requires: /bin/awk
-Requires: coreutils
-Requires: grep
-%{?requires_libtermcap}
-%{?requires_initscripts}
-Requires: xinetd
-Requires: perl >= 5.6.0
-Requires: tar >= %{tarver}
-Requires: readline
+Requires: glib2 >= 2.2.0
 Provides: amanda-backup_client = %{amanda_version}
 Provides: libamclient-%{version}.so = %{amanda_version}
 Provides: libamanda-%{version}.so = %{amanda_version}
@@ -264,13 +163,23 @@ Obsoletes: amanda, amanda-client, amanda-server
 Summary: The Amanda Backup and Archiving Server
 Group: %{rpm_group}
 Requires: /bin/awk
+Requires: /usr/bin/id
+Requires: /sbin/ldconfig
+Requires: /bin/sh
+Requires: gettext
 Requires: coreutils
 Requires: grep
+Requires: gnuplot
+Requires: xinetd
+Requires: %{curl} >= 7.10.0
+Requires: openssl
+Requires: perl >= 5.6.0
+Requires: mailx
 %{?requires_libtermcap}
 %{?requires_initscripts}
 Requires: xinetd
-Requires: perl >= 5.6.0
 Requires: tar >= %{tarver}
+Requires: readline
 Provides: amanda-backup_server = %{amanda_version}
 Provides: libamclient-%{version}.so = %{amanda_version}
 Provides: libamanda-%{version}.so = %{amanda_version}
@@ -285,10 +194,10 @@ Obsoletes: amanda, amanda-client, amanda-server
 %description
 Amanda is the leading Open-Source Backup and Archiving software.
 
-The amanda-backup_server package should be installed on the Amanda server, i.e. 
-the machine attached to backup media (such as a tape drive or disk 
+The amanda-backup_server package should be installed on the Amanda server, i.e.
+the machine attached to backup media (such as a tape drive or disk
 drives) where backups will be written. The amanda-backup_server package
-includes Amanda client.  The amanda-backup_client package needs 
+includes Amanda client.  The amanda-backup_client package needs
 to be installed on every system that is being backed up.
 
 Amanda Forums is located at: http://forums.zmanda.com/
@@ -299,9 +208,9 @@ Amanda Documentation is available at: http://wiki.zmanda.com/
 %description backup_server
 Amanda is the leading Open-Source Backup and Archiving software.
 
-This package contains the Amanda server.  The amanda-backup_server package 
-should be installed on the Amanda server, i.e. the machine attached 
-to backup media (such as a tape drive or disk drives) where backups 
+This package contains the Amanda server.  The amanda-backup_server package
+should be installed on the Amanda server, i.e. the machine attached
+to backup media (such as a tape drive or disk drives) where backups
 will be written.  The amanda-backup_server package includes Amanda client.
 
 Amanda Forums is located at: http://forums.zmanda.com/
@@ -312,7 +221,7 @@ Amanda Documentation is available at: http://wiki.zmanda.com/
 %description backup_client
 Amanda is the leading Open-Source Backup and Archiving software.
 
-This package contains the Amanda client.  The amanda-backup_client package  
+This package contains the Amanda client.  The amanda-backup_client package
 needs to be installed on every system that is being backed up.
 
 Amanda Forums is located at: http://forums.zmanda.com/
@@ -341,7 +250,9 @@ Amanda Documentation is available at: http://wiki.zmanda.com/
 %define INCLUDEDIR      %{PREFIX}/include
 %define MANDIR          %{DATADIR}/man
 %define LOGDIR          /var/log/amanda
-%define PERLSITELIB     %(eval "`perl -V:installsitelib`"; echo $installsitelib)
+%define PERLVENDORARCH   %(eval "perl -V:installvendorarch`"; echo $installvendorarch)
+%define PERLSITEARCH   %(eval "perl -V:installsitearch`"; echo $installsitearch)
+%define PERLLIBDIR      %PERLSITEARCH
 %define AMDATADIR	/var/lib/amanda
 
 # Installation directories:
@@ -357,6 +268,8 @@ Amanda Documentation is available at: http://wiki.zmanda.com/
 %define ROOT_AMDATADIR          %{buildroot}/%{AMDATADIR}
 
 # --- Unpack ---
+
+# %%define _builddir %%{_topdir}/BUILD/%%{name}-%%{amanda_version}
 
 %prep
 %setup -q
@@ -379,8 +292,8 @@ find-req-script
 %{__chmod} u+x %{__find_requires}
 
 %build
-%define config_user %{amanda_user}
-%define config_group %{amanda_group}
+
+[ -x ./configure ] || ./autogen
 
 # Set PKG_CONFIG_PATH=some/path if some/path was set on the command line, or by 
 # the platform detection bits.
@@ -400,15 +313,16 @@ find-req-script
         --localstatedir=%{LOCALSTATEDIR} \
         --libdir=%{LIBDIR} \
         --includedir=%{INCLUDEDIR} \
-        --mandir=%{MANDIR} \
-        --enable-manpage-build \
-        --with-amdatadir=%{AMDATADIR} \
+	--mandir=%{MANDIR} \
+	--with-amdatadir=%{AMDATADIR} \
+	--with-amlibdir=%{AMLIBDIR} \
+	--with-amperldir=%{PERLLIBDIR} \
         --with-gnuplot=/usr/bin/gnuplot \
         --with-gnutar-listdir=%{AMANDAHOMEDIR}/gnutar-lists \
         --with-index-server=localhost \
         --with-tape-server=localhost \
-        --with-user=%{config_user} \
-        --with-group=%{config_group} \
+        --with-user=%{amanda_user} \
+        --with-group=%{amanda_group} \
         --with-owner=%{packer} \
         --with-fqdn \
         --with-bsd-security \
@@ -418,10 +332,13 @@ find-req-script
         --with-ssl-security \
         --with-debugging=%{LOGDIR} \
         --with-assertions \
+        --with-failure-code \
         --disable-installperms \
+        --enable-manpage-build \
         %{?without_ipv6}
 
-make -s LIBTOOLFLAGS=--silent
+# -s LIBTOOLFLAGS=--silent
+make -j$(nproc) 
 
 # --- Install to buildroot ---
 
@@ -435,7 +352,8 @@ else
         exit -1
 fi
 
-make -s -j1 LIBTOOLFLAGS=--silent DESTDIR=%{buildroot} install
+# -s LIBTOOLFLAGS=--silent 
+make -j1 DESTDIR=%{buildroot} install
 
 rm -f %{ROOT_AMANDAHOMEDIR}/example/inetd.conf.amandaclient
 mkdir -p %{buildroot}/{etc,var/log}
@@ -637,7 +555,7 @@ fi
 %%PRE_INST_FUNCTIONS%%
 
 # -------- End Common functions ----------
-logger "Preparing to install: %{amanda_version_info}" 
+logger "Preparing to install: %{amanda_version_info}"
 create_user
 check_user_group "${amanda_group}" || add_group "${amanda_group}"
 check_user_shell "${wanted_shell}"
@@ -710,8 +628,8 @@ cat $LOGFILE >> $INSTALL_LOG && {
     echo "Amanda postinstall logs can be found in '$LOGFILE'."
 
 echo "`date +'%b %e %Y %T'`: Sending anonymous distribution and version information to Zmanda" >> ${INSTALL_LOG}
-if [ -x /usr/bin/wget ]; then 
-        /usr/bin/wget -q -o /dev/null -O - --timeout=5 http://www.zmanda.com/amanda-tips.php\?version=%{amanda_version}\&os=%{disttag}%{distver}\&type=client 
+if [ -x /usr/bin/wget ]; then
+        /usr/bin/wget -q -o /dev/null -O - --timeout=5 http://www.zmanda.com/amanda-tips.php\?version=%{amanda_version}\&os=%{disttag}%{distver}\&type=client
 fi
 
 %postun backup_client
@@ -788,7 +706,7 @@ fi
 %defattr(0755,%{amanda_user},%{amanda_group},0755)
 %{AMLIBEXECDIR}
 %{AMLIBDIR}
-%{PERLSITELIB}/auto/Amanda
+%{PERLLIBDIR}/auto/Amanda
 %defattr(4750,root,disk)
 %{AMLIBEXECDIR}/application/amgtar
 %{AMLIBEXECDIR}/application/amstar
@@ -807,7 +725,7 @@ fi
 %{SYSCONFDIR}/amanda
 %defattr(0644,%{amanda_user},%{amanda_group},0755)
 %{LOCALSTATEDIR}/amanda
-%{PERLSITELIB}/Amanda
+%{PERLLIBDIR}/Amanda
 %{AMLIBEXECDIR}/amcat.awk
 %{AMANDAHOMEDIR}/gnutar-lists
 %doc %{AMANDAHOMEDIR}/amanda-release
@@ -836,8 +754,8 @@ fi
 %defattr(0755,%{amanda_user},%{amanda_group})
 %{AMLIBEXECDIR}
 %{AMLIBDIR}
-%{PERLSITELIB}/Amanda
-%{PERLSITELIB}/auto/Amanda
+%{PERLLIBDIR}/Amanda
+%{PERLLIBDIR}/auto/Amanda
 %{AMANDAHOMEDIR}
 %{LOCALSTATEDIR}/amanda
 %{SBINDIR}/am*

--- a/packaging/rpm/amanda.spec.src
+++ b/packaging/rpm/amanda.spec.src
@@ -363,6 +363,7 @@ mkdir -p %{ROOT_AMANDAHOMEDIR}/gnutar-lists
 mkdir -p %{ROOT_LOGDIR}
 
 echo "%{amanda_version_info}" >%{ROOT_AMANDAHOMEDIR}/amanda-release
+[ -s LONG_BRANCH ] && echo "ref=$(cat LONG_BRANCH)" >>%{ROOT_AMANDAHOMEDIR}/amanda-release
 
 install -m 644 %{ROOT_SYSCONFDIR}/amanda/amanda-security.conf %{ROOT_SYSCONFDIR}
 # --- Clean up buildroot ---


### PR DESCRIPTION
Changes to RPM dependencies and the default location of Perl libs to an architecture-specific location.

(Currently in installsitelib which is /usr/local/share and is *not* architecture dependent).