### PR TITLE
Fix variable declaration in common-src/testutils.h

### DIFF
--- a/common-src/testutils.h
+++ b/common-src/testutils.h
@@ -75,7 +75,7 @@ typedef struct TestUtilsTest {
 #define tu_dbg(...) if (tu_debugging_enabled) { g_fprintf(stderr, __VA_ARGS__); }
 
 /* Is debugging enabled for this test run? (set internally) */
-int tu_debugging_enabled;
+extern gboolean tu_debugging_enabled;
 
 /*
  * Main loop


### PR DESCRIPTION
Added missing `extern` keyword and changed type to be consistent
with `common-src/testutils.c`

This fixes build with GCC 10, where `-fno-common` is default.