### PR TITLE
fix post_inst_functions.sh create_amkey

### DIFF
--- a/packaging/common/post_inst_functions.sh
+++ b/packaging/common/post_inst_functions.sh
@@ -115,7 +115,7 @@ create_amkey() {
     logger "Creating encryption key for amcrypt"
     if [ ! -f ${AMANDAHOMEDIR}/.gnupg/am_key.gpg ]; then
         # TODO: don't write this stuff to disk!
-        get_random_lines 50 >${AMANDAHOMEDIR}/.gnupg/am_key || return 1
+        get_random_lines 65 >${AMANDAHOMEDIR}/.gnupg/am_key || return 1
 
         GPG2=`command -v gpg2 2>/dev/null`
         if [ "$?" != "0" ]; then


### PR DESCRIPTION
aespipe asks for 65 lines for encryption.

verified on CentOS5, CentOS7, Ubuntu18.

Without the fix amreport will report strange dump summary with the package installed key:

data encrypt: Warning: Unknown key data format - using it anyway