### PR TITLE
Fixes  zmanda#112 & uses a Sogis.eu compliant algorithm

### DIFF
--- a/common-src/amcrypt-ossl.sh
+++ b/common-src/amcrypt-ossl.sh
@@ -75,9 +75,9 @@ pad() {
 
 if [ "$1" = -d ]; then
 	# decrypt
-	"${OPENSSL}" enc -d "-${CIPHER}" -nopad -salt -pass fd:3 3< "${PASSPHRASE}"
+	"${OPENSSL}" enc -d -pbkdf2 "-${CIPHER}" -nopad -salt -pass fd:3 3< "${PASSPHRASE}"
 else
 	# encrypt
-	pad | "${OPENSSL}" enc -e "-${CIPHER}" -nopad -salt -pass fd:3 3< "${PASSPHRASE}"
+	pad | "${OPENSSL}" enc -e -pbkdf2 "-${CIPHER}" -nopad -salt -pass fd:3 3< "${PASSPHRASE}"
 fi
 


### PR DESCRIPTION
  sendbackup: info BACKUP=/sbin/dump
  sendbackup: info RECOVER_CMD=/usr/bin/gzip -dc |/sbin/restore -xpGf - ...
  sendbackup: info COMPRESS_SUFFIX=.gz
  sendbackup: info end
  ? *** WARNING : deprecated key derivation used.
  ? Using -iter or -pbkdf2 would be better.
  |   DUMP: WARNING: Cannot use -L on an unmounted filesystem.
  | dump: /XXX: unknown file system
  ? dump (16953) /sbin/dump returned 1
  sendbackup: error [dump (16953) /sbin/dump returned 1]