### PR TITLE
add new helper scripts: working openssl encryption, zstd compression

### DIFF
--- a/common-src/amcrypt-ossl-pbkdf2.sh
+++ b/common-src/amcrypt-ossl-pbkdf2.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# script "encrypt", use with server_encrypt "/whatever/encrypt":
+
+AMANDA_HOME=~amanda
+PASSPHRASE=$AMANDA_HOME/.am_passphrase    # required
+RANDFILE=$AMANDA_HOME/.rnd
+export RANDFILE
+
+if [ "$1" = -d ]; then
+    /usr/bin/openssl enc -pbkdf2 -d -aes-256-ctr -salt -pass fd:3 3< "${PASSPHRASE}"
+else
+    /usr/bin/openssl enc -pbkdf2 -e -aes-256-ctr -salt -pass fd:3 3< "${PASSPHRASE}"
+fi

--- a/common-src/amcrypt-ossl-pbkdf2.sh
+++ b/common-src/amcrypt-ossl-pbkdf2.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
 # script "encrypt", use with server_encrypt "/whatever/encrypt":
+#
+# Author: Anton "exuvo" Olsson
+#         exuvo@exuvo.se
 
 AMANDA_HOME=~amanda
 PASSPHRASE=$AMANDA_HOME/.am_passphrase    # required

--- a/common-src/zstd-compression.sh
+++ b/common-src/zstd-compression.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# script "zstd-compression3", use with server_custom_compress "/whatever/zstd-compression3 :
+
+if [[ "$1" == "-d" ]]; then
+    zstd -dqcf
+else
+    zstd -qc -3 -T0
+fi

--- a/common-src/zstd-compression.sh
+++ b/common-src/zstd-compression.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
 # script "zstd-compression3", use with server_custom_compress "/whatever/zstd-compression3 :
+#
+# Author: Anton "exuvo" Olsson
+#         exuvo@exuvo.se
 
 if [[ "$1" == "-d" ]]; then
     zstd -dqcf


### PR DESCRIPTION
Coming from this PR https://github.com/stefangweichinger/amanda-helpers/pull/3

@exuvo shared his two helper scripts:

* `zstd-compression.sh` does compression/decompression with `zstd`
* `amcrypt-ossl-pbkdf2.sh` does openssl encryption with up to date parameters and maybe fixes #112

Both scripts might go into the next release of Amanda.