### PR TITLE
Working builds for RHEL 8 and RHEL 9

### DIFF
--- a/packaging/rpm/amanda.spec.src
+++ b/packaging/rpm/amanda.spec.src
@@ -134,7 +134,19 @@
         %define distver 7
 	%define curl libcurl
     %endif
-   
+    %if %(awk '$1 == "Red" && $6 ~ /8.*/ { exit 1; }' /etc/redhat-release; echo $?)
+        %define dist redhat
+        %define disttag rhel
+        %define distver 8
+       %define curl libcurl
+    %endif
+    %if %(awk '$1 == "Red" && $6 ~ /9.*/ { exit 1; }' /etc/redhat-release; echo $?)
+        %define dist redhat
+        %define disttag rhel
+        %define distver 9
+       %define curl libcurl
+    %endif
+
     # If dist is undefined, we didn't detect.
     %{!?dist:%define dist unknown}
 %endif


### PR DESCRIPTION
So far this is the minimum change required to build on RHEL 8 and RHEL 9.

Current issues:

- [ ] `rpc/rpc.h` is no longer included in the main devel headers. The files can be found in the `libtirpc-devel` package and can be copied to the correct location. It isn't clear to me how to fix this without building a separate package for the headers.
- [ ] Some headers/libraries for `ndmp` are missing and I am not sure where to find them:

  ```
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_bytes'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_u_long'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_free'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_array'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdrrec_skiprecord'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_string'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdrrec_endofrecord'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_void'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdrrec_create'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_enum'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_short'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_opaque'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_u_char'
  ~/amanda/rpm/BUILD/amanda-4.0.0alpha.git.6fc36428/ndmp-src/.libs/libndmlib.so: undefined reference to `xdr_u_short'
  collect2: error: ld returned 1 exit status
  ```
  It is possible to build with the option `--without-ndmp` to get around this, but I don't know if this feature is commonly used and if that would be a showstopper.
- [ ] On RHEL9, `xinetd` is no longer available. systemd triggers are preferred instead. I am working on that part now.