### PR TITLE
Fixes Open Vulnerability CVE-2022-37705 

### DIFF
--- a/client-src/runtar.c
+++ b/client-src/runtar.c
@@ -191,9 +191,9 @@ main(
 		g_str_has_prefix(argv[i],"--newer") ||
 		g_str_has_prefix(argv[i],"--exclude-from") ||
 		g_str_has_prefix(argv[i],"--files-from")) {
-		/* Accept theses options with the following argument */
-		good_option += 2;
+		good_option++;
 	    } else if (argv[i][0] != '-') {
+		/* argument values are accounted for here */
 		good_option++;
 	    }
 	}


### PR DESCRIPTION
Closes one of vulnerabilities discussed on : #192, CVE-2022-37705.

Context:

with careful selection of arguments, runtar binary can be tricked into invoking shell and since it as SUID bit set and owner is root, it spawns a root shell local low privileged user [reference](https://github.com/MaherAzzouzi/CVE-2022-37705) 

Code Context:

argument check logic for arguments of type `--foo bar` is being misused to skip parsing malicious arguments.

`runtar` keeps `good_option` variable to keep track of good and bad arguments which are in turn passed to the tar command in the exact order specified to `runtar`.

for arguments of type `--foo bar` it increments `good_option` twice ( += 2) accounting for `bar` to be the next argument and skips checking for it, but `--foo bar` can also be specified as `--foo=bar` where value `bar` is already specified for argument `--foo` so with `good_option` still have count >=0 causing immediate argument after this to not checked. 

Fix:

For arguemnts of type `--foo` we only increment count by 1, since there is already a check to account for values to arguments [here](https://github.com/zmanda/amanda/blob/master/client-src/runtar.c#L196)

```
	    } else if (argv[i][0] != '-') {
		good_option++;
	    }
```


