### PR TITLE
Fix to backups failing after Fix to CVE-2022-37704 runtar.c

### DIFF
--- a/client-src/runtar.c
+++ b/client-src/runtar.c
@@ -192,8 +192,9 @@ main(
 		g_str_has_prefix(argv[i],"--exclude-from") ||
 		g_str_has_prefix(argv[i],"--files-from")) {
 		good_option++;
-	    } else if (argv[i][0] != '-') {
+	    } else if (argv[i][0] != '-' || g_str_equal(argv[i], "-")) {
 		/* argument values are accounted for here */
+		/* for --file arguemnt '-' is passed as valid argument from amgtar */
 		good_option++;
 	    }
 	}

--- a/client-src/runtar.c
+++ b/client-src/runtar.c
@@ -194,7 +194,7 @@ main(
 		good_option++;
 	    } else if (argv[i][0] != '-' || g_str_equal(argv[i], "-")) {
 		/* argument values are accounted for here */
-		/* for --file arguemnt '-' is passed as valid argument from amgtar */
+		/* for --file argument '-' is passed as valid argument from amgtar */
 		good_option++;
 	    }
 	}


### PR DESCRIPTION
- amgtar sends '-' as a valid value for argument to --file and this should be accounted for when validating arguments in runtar.c

- fix was merged as part of this MR : https://github.com/zmanda/amanda/pull/196