### PR TITLE
Fix filtering options with arguments starting with -

### DIFF
--- a/client-src/runtar.c
+++ b/client-src/runtar.c
@@ -191,9 +191,13 @@ main(
 		g_str_has_prefix(argv[i],"--newer") ||
 		g_str_has_prefix(argv[i],"--exclude-from") ||
 		g_str_has_prefix(argv[i],"--files-from")) {
-		good_option++;
+		if (strchr(argv[i], '=')) {
+		    good_option++;
+		} else {
+		    /* Accept theses options with the following argument */
+		    good_option += 2;
+		}
 	    } else if (argv[i][0] != '-') {
-		/* argument values are accounted for here */
 		good_option++;
 	    }
 	}


### PR DESCRIPTION
Fixes backups failing after Fix to CVE-2022-37705 runtar.c (#196)

Note this is a different fix than the one merged to [3_5](https://github.com/zmanda/amanda/tree/3_5) branch #204 although the intent is the same.