### PR TITLE
Update the fix for CVE-2022-37704

### DIFF
--- a/client-src/rundump.c
+++ b/client-src/rundump.c
@@ -138,9 +138,10 @@ main(
 
 #ifdef XFSDUMP
 
-    if (g_str_equal(argv[0], "xfsdump"))
+    if (g_str_equal(argv[0], "xfsdump")) {
         dump_program = XFSDUMP;
-    else /* strcmp(argv[0], "xfsdump") != 0 */
+        validate_xfsdump_options(argc, argv);
+    } else /* strcmp(argv[0], "xfsdump") != 0 */
 
 #endif
 
@@ -160,6 +161,7 @@ main(
 
 #endif
 
+      {
 #if defined(DUMP)
         dump_program = DUMP;
         validate_dump_option(argc, argv);
@@ -176,6 +178,7 @@ main(
 #  endif
 # endif
 #endif
+      }
 
     /*
      * Build the array


### PR DESCRIPTION
In the case of xfsdump(8), the check for dump(8) options was invoked instead of the check for the xfsdump(8). This broke legitimate use of xfsdump, while leaving the vulnerability open.