### PR TITLE
Fix file lock write

### DIFF
--- a/common-src/amflock-test.c
+++ b/common-src/amflock-test.c
@@ -103,7 +103,7 @@ static gboolean
 inc_counter(file_lock *lock)
 {
     char old_val = 'a';
-    char new_val[2];
+    char new_val;
 
     if (lock->len) {
 	old_val = lock->data[0];
@@ -111,9 +111,8 @@ inc_counter(file_lock *lock)
 
     g_assert(old_val < 'z');
 
-    new_val[0] = old_val + 1;
-    new_val[1] = '\0';
-    if (file_lock_write(lock, new_val, 1) == -1) {
+    new_val = old_val + 1;
+    if (file_lock_write(lock, &new_val, 1) == -1) {
 	g_fprintf(stderr, "file_lock_write: %s\n",
 			strerror(errno));
 	return FALSE;

--- a/common-src/amflock.c
+++ b/common-src/amflock.c
@@ -314,7 +314,7 @@ file_lock_write(
 
     if (lock->data)
 	g_free(lock->data);
-    lock->data = g_strdup(data);
+    lock->data = g_strndup(data, len);
     lock->len = len;
 
     return 0;

--- a/server-src/server_util.c
+++ b/server-src/server_util.c
@@ -29,7 +29,6 @@
  * $Id: server_util.c,v 1.17 2006/05/25 01:47:20 johnfranks Exp $
  *
  */
-#include "config.h"
 #include <sys/wait.h>
 
 #include "amanda.h"

--- a/server-src/server_util.c
+++ b/server-src/server_util.c
@@ -29,7 +29,7 @@
  * $Id: server_util.c,v 1.17 2006/05/25 01:47:20 johnfranks Exp $
  *
  */
-
+#include "config.h"
 #include <sys/wait.h>
 
 #include "amanda.h"


### PR DESCRIPTION
The implementation of the function `file_lock_write()` looks slightly strange. The library function` g_strdup()` used inside doesn't consider the length of the duplicated data. However, the size of the `data` parameter is restricted by the third parameter `len`, so its value must limit the number of bytes copied during duplication. 

That [patch](https://github.com/zmanda/amanda/commit/6d405d8a282a3aef36bc519823e818a8f7b370fa)  corrects the test function `inc_counter()`, but it looks suspicious to me because it terminates the character value by a zero character instead of checking how the function `file_lock_write()` works in case the `len` parameter equals one and a string is not terminated by a zero character.

