### PR TITLE
configure: Avoid an implicit int in the IPv6 test

### DIFF
--- a/config/amanda/ipv6.m4
+++ b/config/amanda/ipv6.m4
@@ -85,7 +85,7 @@ AC_DEFUN([AMANDA_CHECK_IPV6],
 #include <sys/socket.h>
 #include <errno.h>
 
-main()
+int main(void)
 {
    int aa;
    aa = socket(AF_INET6, SOCK_STREAM, 0);


### PR DESCRIPTION
Otherwise, the test fails unconditionally with compilers that do not support implicit ints (a language feature that was removed with the C99 language revision).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
