### PR TITLE
ambind: fix unsecure use of FD_SET()

### DIFF
--- a/common-src/ambind.c
+++ b/common-src/ambind.c
@@ -58,6 +58,11 @@ main(
     }
     sockfd = atoi(argv[1]);
 
+    if (sockfd < 0 || sockfd >= FD_SETSIZE) {
+        fprintf(stderr, "ambind: incorrect file descriptor provided: %d\n", sockfd);
+        return -1;
+    }
+
     do {
         struct timeval timeout = { 5, 0 };
         fd_set readSet;


### PR DESCRIPTION
ambind does not check user-provided fd value given on its command-line. This fd is then used in calls to `FD_SET()` and then `select()`.

from `man(3) fd_set`:

> An fd_set is a fixed size buffer. Executing FD_CLR() or FD_SET() with a value of fd that is negative or is equal to or larger than FD_SETSIZE will result in undefined
> behavior. Moreover, POSIX requires fd to be a valid file descriptor.

For example, it can be triggered with an int overflow:

```
$ LD_LIBRARY_PATH=./common-src/.libs/:"$LD_LIBRARY_PATH" ./common-src/.libs/ambind 2147483648 zsh: segmentation fault  LD_LIBRARY_PATH=./common-src/.libs/:"$LD_LIBRARY_PATH"  2147483648
```

ltrace stack:

```
$ LD_LIBRARY_PATH=./common-src/.libs/:"$LD_LIBRARY_PATH" ltrace ./common-src/.libs/ambind 2147483648
atoi(0x7ffefcb73354, 0x7ffefcb728e8, 0x7ffefcb72900, 0x55797923ddb8)                                                 = 0x80000000
--- SIGSEGV (Segmentation fault) ---
+++ killed by SIGSEGV +++
```

Current patch fix this behaviour by checking for fd being in range `]0;FD_SETSIZE[`. Note that `FD_SETSIZE` is often 1024 but it is not guaranteed.

I am unsure of the security implications of the misuse. ambind is currently SUID root on my debian. However I do not have a clear picture of how that binary is typically used and how often. It is possible that it can lead to denial of service (DoS) if an attacker can provide the port to bind to but I doubt exploitation could go further. I am interested in getting your feedback on that.

Similar issue in other projects:

https://www.chiark.greenend.org.uk/~sgtatham/putty/wishlist/vuln-fd-set-overflow.html
https://www.cvedetails.com/cve/CVE-2011-0719/