### PR TITLE
C compatibility fixes

### DIFF
--- a/client-src/runtar.c
+++ b/client-src/runtar.c
@@ -54,7 +54,7 @@ main(
 {
 #ifdef GNUTAR
     int i;
-    char **j;
+    const char **j;
     char *e;
     char *dbf;
     char *cmdline;
@@ -255,7 +255,7 @@ check_whitelist(
     gchar* option)
 {
     bool result = TRUE;
-    char** i;
+    const char** i;
 
     for(i=whitelisted_args; *i; i++) {
         if (g_str_has_prefix(option, *i)) {

--- a/config/amanda/ipv6.m4
+++ b/config/amanda/ipv6.m4
@@ -85,7 +85,7 @@ AC_DEFUN([AMANDA_CHECK_IPV6],
 #include <sys/socket.h>
 #include <errno.h>
 
-main()
+int main(void)
 {
    int aa;
    aa = socket(AF_INET6, SOCK_STREAM, 0);


### PR DESCRIPTION
This PR is #220 rebased on top of the `3_5` branch. It also addresses a C compatibility issue in the CVE-2023-30547 fix.