### PR TITLE
Fix libcurl upgrade breaking cloud backups

### DIFF
--- a/device-src/s3.c
+++ b/device-src/s3.c
@@ -2653,19 +2653,29 @@ perform_request(S3Handle *hdl,
 		    goto curl_error;
 	}
 #endif
-
-        if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_HTTPGET, curlopt_httpget)))
-            goto curl_error;
-        if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_UPLOAD, curlopt_upload)))
-            goto curl_error;
-        if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_POST, curlopt_post)))
-            goto curl_error;
-        if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_NOBODY, curlopt_nobody)))
-            goto curl_error;
-        if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_CUSTOMREQUEST,
-                                          curlopt_customrequest)))
-            goto curl_error;
-
+        // set only required http method 
+        // libcurl seems to behave strangely in 7.29 >  i.e. 7.81
+        if(curlopt_httpget) {
+            if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_HTTPGET, curlopt_httpget)))
+                goto curl_error;
+        }
+        if(curlopt_upload) {
+            if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_UPLOAD, curlopt_upload)))
+                goto curl_error;
+        }
+        if(curlopt_post) {
+            if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_POST, curlopt_post)))
+                goto curl_error;
+        }
+        if(curlopt_nobody) {
+            if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_NOBODY, curlopt_nobody)))
+                goto curl_error;
+        }
+        if(curlopt_customrequest) {
+            if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_CUSTOMREQUEST,
+                                            curlopt_customrequest)))
+                goto curl_error;
+        }
 
         if (curlopt_upload || curlopt_post) {
             if ((curl_code = curl_easy_setopt(hdl->curl, CURLOPT_READFUNCTION, read_func)))


### PR DESCRIPTION
- set only required http methods

tested on ubuntu 22.04

certain PUT requests were being set as GET, due to multiple options being set at the same time. this caused a signature mis-match error since there was PUT verb in headers which was signed, and a GET request was being made by libcurl, it is now fixed by setting only required http method.