### PR TITLE
Fix include order in server_util.c for modern glibc compatibility

### DIFF
--- a/server-src/server_util.c
+++ b/server-src/server_util.c
@@ -30,9 +30,9 @@
  *
  */
 
-#include <sys/wait.h>
-
 #include "amanda.h"
+
+#include <sys/wait.h>
 #include "server_util.h"
 #include "logfile.h"
 #include "amutil.h"


### PR DESCRIPTION
## Summary

- Move `#include "amanda.h"` above `#include <sys/wait.h>` in `server-src/server_util.c`

On modern glibc (as found on RHEL 10 / glibc 2.39+), including `<sys/wait.h>` before `amanda.h`
triggers a build failure:

```
gnulib/unistd.h:135:2: error: #error "Please include config.h first."
```

The include chain is:
1. `server_util.c` includes `<sys/wait.h>`
2. `-I../gnulib` intercepts `signal.h`, pulling in gnulib's wrapper
3. That wrapper calls `#include_next <signal.h>` → `bits/sigstksz.h`
4. Which pulls in gnulib's `unistd.h` before `config.h` has been processed

`amanda.h` includes `config.h` as its first action. Moving it first satisfies gnulib's requirement.

## Test plan

- [ ] Build succeeds on RHEL 10.2 (glibc 2.39) with this fix
- [ ] Build continues to succeed on RHEL 9 (glibc 2.34)
- [ ] No functional change — include order only

🤖 Generated with [Claude Code](https://claude.ai/claude-code)